### PR TITLE
added ability to handle 'None' partial charges on OFFMols

### DIFF
--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -220,7 +220,10 @@ class SmallMoleculeTemplateGenerator(object):
         import numpy as np
         from simtk import unit
         zeros = np.zeros([molecule.n_particles])
-        charges_are_zero = np.allclose(molecule.partial_charges / unit.elementary_charge, zeros)
+        if (molecule.partial_charges is None) or (np.allclose(molecule.partial_charges / unit.elementary_charge, zeros)):
+            charges_are_zero = True
+        else:
+            charges_are_zero = False
         return not charges_are_zero
 
     def _generate_unique_atom_names(self, molecule):


### PR DESCRIPTION
This PR fixes an issue that will come up with the upcoming OFF Toolkit 0.7.0 release, where we distinguish between `mol.partial_charges=None` versus `zeros`. More details are here: https://github.com/openforcefield/openforcefield/pull/486#issuecomment-644430643