### PR TITLE
Fix tests to test GLYCAM and use new way of importing for openmm

### DIFF
--- a/openmmforcefields/tests/test_amber_import.py
+++ b/openmmforcefields/tests/test_amber_import.py
@@ -69,5 +69,5 @@ def test_amber_parameterize_ff94():
 
     """
     from pkg_resources import resource_filename
-    pdb_filename = resource_filename('simtk.openmm.app', 'data/test.pdb')
+    pdb_filename = resource_filename('openmm.app', 'data/test.pdb')
     check_ffxml_parameterize(pdb_filename, 'amber/ff94.xml')

--- a/openmmforcefields/tests/test_amber_import.py
+++ b/openmmforcefields/tests/test_amber_import.py
@@ -28,9 +28,9 @@ def test_ffxml_import(filename):
         # Must be used with ff99SB.xml
         filenames = ['amber/ff99SB.xml', 'amber/phosaa10.xml']
         ff = app.ForceField(*filenames)
-    elif filename == 'amber/phosaa14SB.xml':
+    elif filename in ['amber/phosaa14SB.xml', 'amber/GLYCAM_06j-1.xml']:
         # Must be used with ff14SB.xml
-        filenames = ['amber/ff14SB.xml', 'amber/phosaa14SB.xml']
+        filenames = ['amber/ff14SB.xml', filename]
         ff = app.ForceField(*filenames)
     else:
         ff = app.ForceField(filename)

--- a/openmmforcefields/tests/test_amber_import.py
+++ b/openmmforcefields/tests/test_amber_import.py
@@ -28,9 +28,13 @@ def test_ffxml_import(filename):
         # Must be used with ff99SB.xml
         filenames = ['amber/ff99SB.xml', 'amber/phosaa10.xml']
         ff = app.ForceField(*filenames)
-    elif filename in ['amber/phosaa14SB.xml', 'amber/GLYCAM_06j-1.xml']:
+    elif filename == 'amber/phosaa14SB.xml':
         # Must be used with ff14SB.xml
-        filenames = ['amber/ff14SB.xml', filename]
+        filenames = ['amber/ff14SB.xml', 'amber/phosaa14SB.xml']
+        ff = app.ForceField(*filenames)
+    elif filename == 'amber/GLYCAM_06j-1.xml':
+        # Must be used with protein.ff14SB.xml
+        filenames = ['amber/protein.ff14SB.xml', 'amber/GLYCAM_06j-1.xml']
         ff = app.ForceField(*filenames)
     else:
         ff = app.ForceField(filename)


### PR DESCRIPTION
This PR modifies `test_amber_import.py::test_ffxml_import` to handle testing the `amber/GLYCAM_06j-1.xml`. 

`amber/protein.ff14SB.xml` must be loaded alongside `amber/GLYCAM_06j-1.xml` when testing.