### PR TITLE
Fix glycam ffxml and conversion script

### DIFF
--- a/amber/convert_amber.py
+++ b/amber/convert_amber.py
@@ -1493,19 +1493,37 @@ def modify_glycan_ffxml(input_ffxml_path):
 
     # Add initialization script for setting up GlycamTemplateMatcher
     initialization_script = etree.SubElement(root, 'InitializationScript')
-    initialization_script.text = """
+    initialization_script.text = """ 
+from openmm.app.internal import compiled
+
 class GlycamTemplateMatcher(object):
+
   def __init__(self, glycam_residues):
     self.glycam_residues = glycam_residues
-  def __call__(self, ff, residue):
+
+  def __call__(self, ff, residue, bondedToAtom, ignoreExternalBonds, ignoreExtraParticles):
     if residue.name in self.glycam_residues:
-      return ff._templates[residue.name]
+      template = ff._templates[residue.name]
+      if compiled.matchResidueToTemplate(residue, template, bondedToAtom, ignoreExternalBonds, ignoreExtraParticles) is not None:
+        return template
+
+      # The residue doesn't actually match the template with the same name.  Try the terminal variants.
+
+      if 'N'+residue.name in self.glycam_residues:
+        template = ff._templates['N'+residue.name]
+        if compiled.matchResidueToTemplate(residue, template, bondedToAtom, ignoreExternalBonds, ignoreExtraParticles) is not None:
+          return template
+      if 'C'+residue.name in self.glycam_residues:
+        template = ff._templates['C'+residue.name]
+        if compiled.matchResidueToTemplate(residue, template, bondedToAtom, ignoreExternalBonds, ignoreExtraParticles) is not None:
+          return template
     return None
 
 glycam_residues = set()
 for residue in tree.getroot().find('Residues').findall('Residue'):
   glycam_residues.add(residue.get('name'))
 self.registerTemplateMatcher(GlycamTemplateMatcher(glycam_residues))
+
 """
 
     tree.write(input_ffxml_path)

--- a/amber/convert_amber.py
+++ b/amber/convert_amber.py
@@ -3,8 +3,7 @@
 from __future__ import print_function, division
 from io import StringIO
 import parmed
-from parmed.utils.six import iteritems
-from parmed.utils.six.moves import StringIO, zip
+import openmm
 import openmm.app as app
 import openmm.unit as u
 import os

--- a/amber/ffxml/GLYCAM_06j-1.xml
+++ b/amber/ffxml/GLYCAM_06j-1.xml
@@ -342,8 +342,8 @@
       <Bond atomName1="C2M" atomName2="H22" />
       <Bond atomName1="C2M" atomName2="H21" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4N" />
       <ExternalBond atomName="C4N" />
+      <ExternalBond atomName="O4N" />
     </Residue>
     <Residue name="0BD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -1139,11 +1139,11 @@
       <Bond atomName1="OHG" atomName2="HOG" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O5N" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
+      <ExternalBond atomName="O5N" />
     </Residue>
     <Residue name="0HA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -1841,9 +1841,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="0OB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -1887,9 +1887,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="0PA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -2401,11 +2401,11 @@
       <Bond atomName1="CME" atomName2="H1M" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O5N" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
+      <ExternalBond atomName="O5N" />
     </Residue>
     <Residue name="0SB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -2483,11 +2483,11 @@
       <Bond atomName1="C1" atomName2="O1B" />
       <Bond atomName1="C1" atomName2="O1A" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
+      <ExternalBond atomName="O1A" />
     </Residue>
     <Residue name="0TA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -2711,9 +2711,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="0UB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -2757,9 +2757,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="0VA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -3313,9 +3313,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="0ZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -3359,9 +3359,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="0aA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -3681,8 +3681,8 @@
       <Bond atomName1="C2M" atomName2="H22" />
       <Bond atomName1="C2M" atomName2="H23" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4N" />
       <ExternalBond atomName="C4N" />
+      <ExternalBond atomName="O4N" />
     </Residue>
     <Residue name="0bD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -4478,11 +4478,11 @@
       <Bond atomName1="C1" atomName2="O1B" />
       <Bond atomName1="C1" atomName2="O1A" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
+      <ExternalBond atomName="O1A" />
     </Residue>
     <Residue name="0hA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -5180,9 +5180,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="0oB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -5226,9 +5226,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="0pA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -5740,11 +5740,11 @@
       <Bond atomName1="C1" atomName2="O1B" />
       <Bond atomName1="C1" atomName2="O1A" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
+      <ExternalBond atomName="O1A" />
     </Residue>
     <Residue name="0sB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -5822,11 +5822,11 @@
       <Bond atomName1="CME" atomName2="H3M" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O5N" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
+      <ExternalBond atomName="O5N" />
     </Residue>
     <Residue name="0tA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -6050,9 +6050,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="0uB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -6096,9 +6096,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="0vA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -6652,9 +6652,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="0zB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -6698,9 +6698,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="1AA" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -8402,9 +8402,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="1OB" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -8450,9 +8450,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="1PA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -9128,9 +9128,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="1UB" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -9176,9 +9176,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="1VA" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -9754,9 +9754,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="1ZB" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -9802,9 +9802,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="1aA" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -11506,9 +11506,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="1oB" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -11554,9 +11554,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="1pA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -12232,9 +12232,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="1uB" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -12280,9 +12280,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="1vA" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -12858,9 +12858,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="1zB" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -12906,9 +12906,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="2AA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -40762,8 +40762,8 @@
       <Bond atomName1="ND2" atomName2="HD21" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="ND2" />
+      <ExternalBond atomName="C" />
     </Residue>
     <Residue name="OLS" override="1">
       <Atom name="N" type="protein-N" charge="-0.4157" />
@@ -40786,8 +40786,8 @@
       <Bond atomName1="CB" atomName2="OG" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="OG" />
+      <ExternalBond atomName="C" />
     </Residue>
     <Residue name="OLT" override="1">
       <Atom name="N" type="protein-N" charge="-0.4157" />
@@ -40816,8 +40816,8 @@
       <Bond atomName1="CG2" atomName2="HG23" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="OG1" />
+      <ExternalBond atomName="C" />
     </Residue>
     <Residue name="OME" override="1">
       <Atom name="H1" type="protein-H1" charge="0.0" />
@@ -66413,8 +66413,8 @@
       <Bond atomName1="CA" atomName2="C" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="OD1" />
+      <ExternalBond atomName="C" />
     </Residue>
     <Residue name="CHYP" override="1">
       <Atom name="N" type="protein-N" charge="-0.28" />

--- a/amber/ffxml/GLYCAM_06j-1.xml
+++ b/amber/ffxml/GLYCAM_06j-1.xml
@@ -40762,8 +40762,8 @@
       <Bond atomName1="ND2" atomName2="HD21" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="ND2" />
       <ExternalBond atomName="C" />
+      <ExternalBond atomName="ND2" />
     </Residue>
     <Residue name="OLS" override="1">
       <Atom name="N" type="protein-N" charge="-0.4157" />
@@ -40786,8 +40786,8 @@
       <Bond atomName1="CB" atomName2="OG" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="OG" />
       <ExternalBond atomName="C" />
+      <ExternalBond atomName="OG" />
     </Residue>
     <Residue name="OLT" override="1">
       <Atom name="N" type="protein-N" charge="-0.4157" />
@@ -40816,8 +40816,8 @@
       <Bond atomName1="CG2" atomName2="HG23" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="OG1" />
       <ExternalBond atomName="C" />
+      <ExternalBond atomName="OG1" />
     </Residue>
     <Residue name="OME" override="1">
       <Atom name="H1" type="protein-H1" charge="0.0" />
@@ -66413,8 +66413,8 @@
       <Bond atomName1="CA" atomName2="C" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="OD1" />
       <ExternalBond atomName="C" />
+      <ExternalBond atomName="OD1" />
     </Residue>
     <Residue name="CHYP" override="1">
       <Atom name="N" type="protein-N" charge="-0.28" />

--- a/amber/ffxml/GLYCAM_06j-1.xml
+++ b/amber/ffxml/GLYCAM_06j-1.xml
@@ -1,6 +1,6 @@
 <ForceField>
   <Info>
-    <DateGenerated>2021-10-28</DateGenerated>
+    <DateGenerated>2021-10-29</DateGenerated>
     <Source Source="glycam/leaprc.GLYCAM_06j-1" md5hash="a7359f8d717f92dba02d57d6e0c8f3f7" sourcePackage="AmberTools" sourcePackageVersion="20.15">glycam/leaprc.GLYCAM_06j-1</Source>
     <Reference>R. Kadirvelraj; O. C. Grant; I. J. Goldstein; H. C. Winter; H. Tateno; E. Fadda; R. J. Woods. Structure and binding analysis of Polyporus squamosus lectin in complex with the Neu5Ac&#945;2-6Gal&#946;1-4GlcNAc human- type influenza receptor. Glycobiology, 2011, 21, 973&#8211;984. M. L. DeMarco; R. J. Woods. From agonist to antagonist: Structure and dynamics of innate immune glycoprotein MD-2 upon recognition of variably acylated bacterial endotoxins. Mol. Immunol., 2011, 49, 124&#8211;133. B. L. Foley; M. B. Tessier; R. J. Woods. Carbohydrate force fields. WIREs Comput. Mol. Sci., 2012, 2, 652&#8211;697. E. Ficko-Blean; C. P. Stuart; M. D. Suits; M. Cid; M. Tessier; R. J. Woods; A. B. Boraston. Carbohy- drate Recognition by an Architecturally Complex &#945;-N-Acetylglucosaminidase from Clostridium perfrin- gens. PLoS ONE, 2012, 7, e33524.</Reference>
   </Info>
@@ -342,8 +342,8 @@
       <Bond atomName1="C2M" atomName2="H22" />
       <Bond atomName1="C2M" atomName2="H21" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="C4N" />
       <ExternalBond atomName="O4N" />
+      <ExternalBond atomName="C4N" />
     </Residue>
     <Residue name="0BD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -1139,11 +1139,11 @@
       <Bond atomName1="OHG" atomName2="HOG" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O5N" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
-      <ExternalBond atomName="O5N" />
     </Residue>
     <Residue name="0HA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -1841,9 +1841,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="0OB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -1887,9 +1887,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="0PA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -2401,11 +2401,11 @@
       <Bond atomName1="CME" atomName2="H1M" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O5N" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
-      <ExternalBond atomName="O5N" />
     </Residue>
     <Residue name="0SB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -2483,11 +2483,11 @@
       <Bond atomName1="C1" atomName2="O1B" />
       <Bond atomName1="C1" atomName2="O1A" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
-      <ExternalBond atomName="O1A" />
     </Residue>
     <Residue name="0TA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -2711,9 +2711,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="0UB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -2757,9 +2757,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="0VA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -3313,9 +3313,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="0ZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -3359,9 +3359,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="0aA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -3681,8 +3681,8 @@
       <Bond atomName1="C2M" atomName2="H22" />
       <Bond atomName1="C2M" atomName2="H23" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="C4N" />
       <ExternalBond atomName="O4N" />
+      <ExternalBond atomName="C4N" />
     </Residue>
     <Residue name="0bD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -4478,11 +4478,11 @@
       <Bond atomName1="C1" atomName2="O1B" />
       <Bond atomName1="C1" atomName2="O1A" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
-      <ExternalBond atomName="O1A" />
     </Residue>
     <Residue name="0hA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -5180,9 +5180,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="0oB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -5226,9 +5226,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="0pA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -5740,11 +5740,11 @@
       <Bond atomName1="C1" atomName2="O1B" />
       <Bond atomName1="C1" atomName2="O1A" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
-      <ExternalBond atomName="O1A" />
     </Residue>
     <Residue name="0sB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -5822,11 +5822,11 @@
       <Bond atomName1="CME" atomName2="H3M" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O5N" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
-      <ExternalBond atomName="O5N" />
     </Residue>
     <Residue name="0tA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -6050,9 +6050,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="0uB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -6096,9 +6096,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="0vA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -6652,9 +6652,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="0zB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -6698,9 +6698,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="1AA" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -8402,9 +8402,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
+      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="1OB" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -8450,9 +8450,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
+      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="1PA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -9128,9 +9128,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
+      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="1UB" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -9176,9 +9176,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
+      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="1VA" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -9754,9 +9754,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
+      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="1ZB" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -9802,9 +9802,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
+      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="1aA" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -11506,9 +11506,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
+      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="1oB" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -11554,9 +11554,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
+      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="1pA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -12232,9 +12232,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
+      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="1uB" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -12280,9 +12280,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
+      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="1vA" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -12858,9 +12858,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
+      <ExternalBond atomName="O6A" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O6A" />
     </Residue>
     <Residue name="1zB" override="1">
       <Atom name="O1" type="glycam-Os" charge="-0.388" />
@@ -12906,9 +12906,9 @@
       <Bond atomName1="O3" atomName2="H3O" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="O1" />
+      <ExternalBond atomName="O6B" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O6B" />
     </Residue>
     <Residue name="2AA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -14570,10 +14570,10 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2OB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -14615,10 +14615,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2PA" override="1">
       <Atom name="O2" type="glycam-Os" charge="-0.388" />
@@ -15272,10 +15272,10 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2UB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -15317,10 +15317,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2XA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -15514,10 +15514,10 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2ZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -15559,10 +15559,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2aA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -17224,10 +17224,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2oB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -17269,10 +17269,10 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2pA" override="1">
       <Atom name="O2" type="glycam-Os" charge="-0.388" />
@@ -17926,10 +17926,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2uB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -17971,10 +17971,10 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2xA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -18168,10 +18168,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2zB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -18213,10 +18213,10 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="3AA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -18528,9 +18528,9 @@
       <Bond atomName1="C4M" atomName2="H42" />
       <Bond atomName1="C4M" atomName2="H41" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C4N" />
       <ExternalBond atomName="O4N" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3BD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -19912,10 +19912,10 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3OB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -19957,10 +19957,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3PA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -20518,10 +20518,10 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3UB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -20563,10 +20563,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3VA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -21108,10 +21108,10 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3ZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -21153,10 +21153,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3aA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -21468,9 +21468,9 @@
       <Bond atomName1="C2M" atomName2="H22" />
       <Bond atomName1="C2M" atomName2="H23" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C4N" />
       <ExternalBond atomName="O4N" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3bD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -22852,10 +22852,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3oB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -22897,10 +22897,10 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3pA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -23458,10 +23458,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3uB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -23503,10 +23503,10 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3vA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -24048,10 +24048,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3zB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -24093,10 +24093,10 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="4AA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -24966,12 +24966,12 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4HA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -25653,10 +25653,10 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4OB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -25698,10 +25698,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4PA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -26125,12 +26125,12 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4SB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -26206,12 +26206,12 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4TA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -26429,10 +26429,10 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4UB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -26474,10 +26474,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4VA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -26943,10 +26943,10 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4ZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -26988,10 +26988,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4aA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -27861,12 +27861,12 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4hA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -28548,10 +28548,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4oB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -28593,10 +28593,10 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4pA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -29020,12 +29020,12 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4sB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -29101,12 +29101,12 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4tA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -29324,10 +29324,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4uB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -29369,10 +29369,10 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4vA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -29838,10 +29838,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4zB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -29883,10 +29883,10 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="5AD" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.368" />
@@ -34028,12 +34028,12 @@
       <Bond atomName1="O9" atomName2="H9O" />
       <Bond atomName1="O8" atomName2="H8O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="7SA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -34109,12 +34109,12 @@
       <Bond atomName1="O9" atomName2="H9O" />
       <Bond atomName1="O8" atomName2="H8O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="7SB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -34190,12 +34190,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="7gL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -34273,12 +34273,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="7sA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -34354,12 +34354,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="7sB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -34435,12 +34435,12 @@
       <Bond atomName1="O9" atomName2="H9O" />
       <Bond atomName1="O8" atomName2="H8O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="8GL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -34518,12 +34518,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="8SA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -34599,12 +34599,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="8SB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -34680,12 +34680,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="8gL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -34763,12 +34763,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="8sA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -34844,12 +34844,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="8sB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -34925,12 +34925,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="9GL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -35008,12 +35008,12 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O9" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O9" />
     </Residue>
     <Residue name="9SA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -35089,12 +35089,12 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O9" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O9" />
     </Residue>
     <Residue name="9SB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -35170,12 +35170,12 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O9" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O9" />
     </Residue>
     <Residue name="9gL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -35253,12 +35253,12 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O9" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O9" />
     </Residue>
     <Residue name="9sA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -35334,12 +35334,12 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O9" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O9" />
     </Residue>
     <Residue name="9sB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -35415,12 +35415,12 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O9" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O9" />
     </Residue>
     <Residue name="ACX" override="1">
       <Atom name="C1A" type="protein-C" charge="0.763" />
@@ -35507,6 +35507,7 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -35515,7 +35516,6 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ASA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -35585,6 +35585,7 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -35593,7 +35594,6 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ASB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -35663,6 +35663,7 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -35671,7 +35672,6 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="AgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -35743,6 +35743,7 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -35751,7 +35752,6 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="AsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -35821,6 +35821,7 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -35829,7 +35830,6 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="AsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -35899,6 +35899,7 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -35907,7 +35908,6 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="BGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -35981,6 +35981,7 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -35988,7 +35989,6 @@
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="O8" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="BSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -36060,6 +36060,7 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -36067,7 +36068,6 @@
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="O8" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="BSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -36139,6 +36139,7 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -36146,7 +36147,6 @@
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="BgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -36220,6 +36220,7 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -36227,7 +36228,6 @@
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="BsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -36299,6 +36299,7 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -36306,7 +36307,6 @@
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="BsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -36378,6 +36378,7 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -36385,7 +36386,6 @@
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="O8" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="CGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -36459,6 +36459,7 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -36466,7 +36467,6 @@
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="CSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -36538,6 +36538,7 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -36545,7 +36546,6 @@
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="CSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -36617,6 +36617,7 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -36624,7 +36625,6 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="CgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -36698,6 +36698,7 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -36705,7 +36706,6 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="CsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -36777,6 +36777,7 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -36784,7 +36785,6 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="CsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -36856,6 +36856,7 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -36863,7 +36864,6 @@
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="DGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -36937,6 +36937,7 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -36944,7 +36945,6 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="DSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -37016,6 +37016,7 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -37023,7 +37024,6 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="DSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -37095,6 +37095,7 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -37102,7 +37103,6 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="DgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -37176,6 +37176,7 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -37183,7 +37184,6 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="DsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -37255,6 +37255,7 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -37262,7 +37263,6 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="DsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -37334,6 +37334,7 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -37341,7 +37342,6 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="EGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -37415,6 +37415,7 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -37422,7 +37423,6 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ESA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -37494,6 +37494,7 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -37501,7 +37502,6 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ESB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -37573,6 +37573,7 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -37580,7 +37581,6 @@
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="EgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -37654,6 +37654,7 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -37661,7 +37662,6 @@
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="EsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -37733,6 +37733,7 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -37740,7 +37741,6 @@
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="EsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -37812,6 +37812,7 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -37819,7 +37820,6 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="FGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -37895,13 +37895,13 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="FSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -37975,13 +37975,13 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="FSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -38055,13 +38055,13 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="FgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -38137,13 +38137,13 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="FsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -38217,13 +38217,13 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="FsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -38297,13 +38297,13 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="GGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -38379,13 +38379,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O8" atomName2="H8O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="GSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -38459,13 +38459,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O8" atomName2="H8O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="GSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -38539,13 +38539,13 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="GgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -38621,13 +38621,13 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="GsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -38701,13 +38701,13 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="GsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -38781,13 +38781,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O8" atomName2="H8O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="HGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -38863,13 +38863,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="HSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -38943,13 +38943,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="HSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -39023,13 +39023,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="HgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -39105,13 +39105,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="HsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -39185,13 +39185,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="HsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -39265,13 +39265,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
-      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="IGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -39347,13 +39347,13 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ISA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -39427,13 +39427,13 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ISB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -39507,13 +39507,13 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="IgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -39589,13 +39589,13 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="IsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -39669,13 +39669,13 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="IsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -39749,13 +39749,13 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="JGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -39831,13 +39831,13 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="JSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -39911,13 +39911,13 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="JSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -39991,13 +39991,13 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="JgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -40073,13 +40073,13 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="JsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -40153,13 +40153,13 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="JsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -40233,13 +40233,13 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="KGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -40315,13 +40315,13 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="KSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -40395,13 +40395,13 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="KSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -40475,13 +40475,13 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="KgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -40557,13 +40557,13 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="KsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -40637,13 +40637,13 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="KsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -40717,13 +40717,13 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
-      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="MEX" override="1">
       <Atom name="CH3" type="glycam-Cg" charge="0.233" />
@@ -40762,8 +40762,8 @@
       <Bond atomName1="ND2" atomName2="HD21" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="ND2" />
       <ExternalBond atomName="C" />
+      <ExternalBond atomName="ND2" />
     </Residue>
     <Residue name="OLS" override="1">
       <Atom name="N" type="protein-N" charge="-0.4157" />
@@ -40786,8 +40786,8 @@
       <Bond atomName1="CB" atomName2="OG" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="OG" />
       <ExternalBond atomName="C" />
+      <ExternalBond atomName="OG" />
     </Residue>
     <Residue name="OLT" override="1">
       <Atom name="N" type="protein-N" charge="-0.4157" />
@@ -40816,8 +40816,8 @@
       <Bond atomName1="CG2" atomName2="HG23" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="OG1" />
       <ExternalBond atomName="C" />
+      <ExternalBond atomName="OG1" />
     </Residue>
     <Residue name="OME" override="1">
       <Atom name="H1" type="protein-H1" charge="0.0" />
@@ -40869,10 +40869,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -40912,10 +40912,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -40955,10 +40955,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -40998,10 +40998,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -41041,10 +41041,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -41084,10 +41084,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -41127,10 +41127,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -41170,10 +41170,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -41213,10 +41213,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -41256,10 +41256,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -41299,10 +41299,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -41342,10 +41342,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -41385,10 +41385,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -41428,10 +41428,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -41471,10 +41471,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -41514,10 +41514,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -41557,10 +41557,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -41600,10 +41600,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -41643,10 +41643,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -41686,10 +41686,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -41729,10 +41729,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -41772,10 +41772,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -41815,10 +41815,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -41858,10 +41858,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -41901,10 +41901,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -41944,10 +41944,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -41987,10 +41987,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -42030,10 +42030,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="QBD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -42075,9 +42075,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QBU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -42119,9 +42119,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QCD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -42163,9 +42163,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QCU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -42207,9 +42207,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -42251,9 +42251,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -42295,9 +42295,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -42339,9 +42339,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -42383,9 +42383,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QJD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -42427,9 +42427,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QJU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -42471,9 +42471,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -42515,9 +42515,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -42559,9 +42559,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -42603,9 +42603,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -42647,9 +42647,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -42691,9 +42691,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -42735,9 +42735,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -42779,9 +42779,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -42823,9 +42823,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QPD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -42867,9 +42867,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QPU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -42911,9 +42911,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -42955,9 +42955,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -42999,9 +42999,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QVA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -43055,9 +43055,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QVB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -43111,9 +43111,9 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QWA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -43167,9 +43167,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QWB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -43223,9 +43223,9 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QYA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -43279,9 +43279,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QYB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -43335,9 +43335,9 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QbD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -43379,9 +43379,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QbU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -43423,9 +43423,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QcD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -43467,9 +43467,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QcU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -43511,9 +43511,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -43555,9 +43555,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -43599,9 +43599,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -43643,9 +43643,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -43687,9 +43687,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QjD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -43731,9 +43731,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QjU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -43775,9 +43775,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -43819,9 +43819,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -43863,9 +43863,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -43907,9 +43907,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -43951,9 +43951,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -43995,9 +43995,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -44039,9 +44039,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -44083,9 +44083,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -44127,9 +44127,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QpD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -44171,9 +44171,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QpU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -44215,9 +44215,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -44259,9 +44259,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -44303,9 +44303,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QvA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -44359,9 +44359,9 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QvB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -44415,9 +44415,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QwA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -44471,9 +44471,9 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QwB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -44527,9 +44527,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QyA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -44583,9 +44583,9 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QyB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -44639,9 +44639,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="REA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -44683,9 +44683,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="REB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -44727,9 +44727,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -44771,9 +44771,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -44815,9 +44815,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -44859,9 +44859,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -44903,9 +44903,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -44947,9 +44947,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -44991,9 +44991,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -45035,9 +45035,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -45079,9 +45079,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -45123,9 +45123,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -45167,9 +45167,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ROH" override="1">
       <Atom name="HO1" type="glycam-Ho" charge="0.445" />
@@ -45217,9 +45217,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -45261,9 +45261,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ReA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -45305,9 +45305,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ReB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -45349,9 +45349,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -45393,9 +45393,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -45437,9 +45437,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -45481,9 +45481,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -45525,9 +45525,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -45569,9 +45569,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -45613,9 +45613,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -45657,9 +45657,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -45701,9 +45701,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -45745,9 +45745,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -45789,9 +45789,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -45833,9 +45833,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -45877,9 +45877,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -45921,9 +45921,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -45965,9 +45965,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -46009,9 +46009,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -46053,9 +46053,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -46097,9 +46097,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -46141,9 +46141,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -46185,9 +46185,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -46229,9 +46229,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -46273,9 +46273,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -46317,9 +46317,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -46361,9 +46361,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -46405,9 +46405,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SO3" override="1">
       <Atom name="S1" type="protein-S" charge="1.245" />
@@ -46459,9 +46459,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="STB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -46503,9 +46503,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -46547,9 +46547,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -46591,9 +46591,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -46635,9 +46635,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -46679,9 +46679,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -46723,9 +46723,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -46767,9 +46767,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -46811,9 +46811,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -46855,9 +46855,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -46899,9 +46899,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -46943,9 +46943,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -46987,9 +46987,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -47031,9 +47031,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="StA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -47075,9 +47075,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="StB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -47119,9 +47119,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TAA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -47155,9 +47155,9 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TAB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -47191,9 +47191,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TBT" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.021" />
@@ -47257,9 +47257,9 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TDB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -47293,9 +47293,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -47337,9 +47337,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -47381,9 +47381,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TFA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -47423,9 +47423,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TFB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -47465,9 +47465,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -47509,9 +47509,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -47553,9 +47553,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="THA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -47595,9 +47595,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="THB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -47637,9 +47637,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -47681,9 +47681,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -47725,9 +47725,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -47769,9 +47769,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -47813,9 +47813,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -47857,9 +47857,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -47901,9 +47901,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -47945,9 +47945,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -47989,9 +47989,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TOA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -48029,12 +48029,12 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TOB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -48072,12 +48072,12 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TQA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -48117,9 +48117,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TQB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -48159,9 +48159,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TRA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -48195,9 +48195,9 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TRB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -48231,9 +48231,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -48275,9 +48275,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -48319,9 +48319,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TUA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -48359,12 +48359,12 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TUB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -48402,12 +48402,12 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TXA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -48441,9 +48441,9 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TXB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -48477,9 +48477,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TZA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -48517,12 +48517,12 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -48560,12 +48560,12 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TaA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -48599,9 +48599,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TaB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -48635,9 +48635,9 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TdA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -48671,9 +48671,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TdB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -48707,9 +48707,9 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -48751,9 +48751,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -48795,9 +48795,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TfA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -48837,9 +48837,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TfB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -48879,9 +48879,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H63" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -48923,9 +48923,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -48967,9 +48967,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ThA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -49009,9 +49009,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ThB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -49051,9 +49051,9 @@
       <Bond atomName1="C6M" atomName2="H2M" />
       <Bond atomName1="C6M" atomName2="H1M" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -49095,9 +49095,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -49139,9 +49139,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -49183,9 +49183,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -49227,9 +49227,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -49271,9 +49271,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -49315,9 +49315,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -49359,9 +49359,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -49403,9 +49403,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ToA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -49443,12 +49443,12 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ToB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -49486,12 +49486,12 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TqA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -49531,9 +49531,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TqB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -49573,9 +49573,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H63" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TrA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -49609,9 +49609,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TrB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -49645,9 +49645,9 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -49689,9 +49689,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -49733,9 +49733,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TuA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -49773,12 +49773,12 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TuB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -49816,12 +49816,12 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TxA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -49855,9 +49855,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TxB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -49891,9 +49891,9 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TzA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -49931,12 +49931,12 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TzB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -49974,12 +49974,12 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="UBD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -50023,8 +50023,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UBU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -50068,8 +50068,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UCD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -50113,8 +50113,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UCU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -50158,8 +50158,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -50203,8 +50203,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -50248,8 +50248,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -50293,8 +50293,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -50338,8 +50338,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UJD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -50383,8 +50383,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UJU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -50428,8 +50428,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -50473,8 +50473,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -50518,8 +50518,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="ULA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -50563,8 +50563,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="ULB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -50608,8 +50608,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -50653,8 +50653,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -50698,8 +50698,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -50743,8 +50743,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -50788,8 +50788,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UPD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -50833,8 +50833,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UPU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -50878,8 +50878,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -50923,8 +50923,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -50968,8 +50968,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UVA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -51025,8 +51025,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UVB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -51082,8 +51082,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UWA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -51139,8 +51139,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UWB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -51196,8 +51196,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UYA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -51253,8 +51253,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UYB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -51310,8 +51310,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UbD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -51355,8 +51355,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UbU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -51400,8 +51400,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UcD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -51445,8 +51445,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UcU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -51490,8 +51490,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -51535,8 +51535,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -51580,8 +51580,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -51625,8 +51625,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -51670,8 +51670,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UjD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -51715,8 +51715,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UjU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -51760,8 +51760,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -51805,8 +51805,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -51850,8 +51850,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -51895,8 +51895,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -51940,8 +51940,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -51985,8 +51985,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -52030,8 +52030,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -52075,8 +52075,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -52120,8 +52120,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UpD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -52165,8 +52165,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UpU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -52210,8 +52210,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -52255,8 +52255,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -52300,8 +52300,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UvA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -52357,8 +52357,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UvB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -52414,8 +52414,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UwA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -52471,8 +52471,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UwB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -52528,8 +52528,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UyA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -52585,8 +52585,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="UyB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -52642,8 +52642,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VBD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -52687,8 +52687,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VBU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -52732,8 +52732,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VCD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -52777,8 +52777,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VCU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -52822,8 +52822,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -52867,8 +52867,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -52912,8 +52912,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -52957,8 +52957,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -53002,8 +53002,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VJD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -53047,8 +53047,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VJU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -53092,8 +53092,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -53137,8 +53137,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -53182,8 +53182,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -53227,8 +53227,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -53272,8 +53272,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -53317,8 +53317,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -53362,8 +53362,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -53407,8 +53407,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -53452,8 +53452,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VPD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -53497,8 +53497,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VPU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -53542,8 +53542,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -53587,8 +53587,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -53632,8 +53632,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VVA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -53689,8 +53689,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VVB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -53746,8 +53746,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VWA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -53803,8 +53803,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VWB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -53860,8 +53860,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VYA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -53917,8 +53917,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VYB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -53974,8 +53974,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VbD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -54019,8 +54019,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VbU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -54064,8 +54064,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VcD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -54109,8 +54109,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VcU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -54154,8 +54154,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -54199,8 +54199,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -54244,8 +54244,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -54289,8 +54289,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -54334,8 +54334,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VjD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -54379,8 +54379,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VjU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -54424,8 +54424,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -54469,8 +54469,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -54514,8 +54514,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -54559,8 +54559,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -54604,8 +54604,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -54649,8 +54649,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -54694,8 +54694,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -54739,8 +54739,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -54784,8 +54784,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VpD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -54829,8 +54829,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VpU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -54874,8 +54874,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -54919,8 +54919,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -54964,8 +54964,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VvA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -55021,8 +55021,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VvB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -55078,8 +55078,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VwA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -55135,8 +55135,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VwB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -55192,8 +55192,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VyA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -55249,8 +55249,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="VyB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -55306,8 +55306,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="WAA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -55343,8 +55343,8 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WAB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -55380,8 +55380,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WBA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.13" />
@@ -55425,8 +55425,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WBB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.227" />
@@ -55470,8 +55470,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WBD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -55515,8 +55515,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WBU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -55560,8 +55560,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WCA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.345" />
@@ -55605,8 +55605,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WCB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.244" />
@@ -55650,8 +55650,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WCD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -55695,8 +55695,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WCU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -55740,8 +55740,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WDA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -55777,8 +55777,8 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WDB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -55814,8 +55814,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -55859,8 +55859,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -55904,8 +55904,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WFA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -55947,8 +55947,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WFB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -55990,8 +55990,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -56035,8 +56035,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -56080,8 +56080,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WHA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -56123,8 +56123,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WHB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -56166,8 +56166,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WJA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.114" />
@@ -56211,8 +56211,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WJB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.413" />
@@ -56256,8 +56256,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WJD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -56301,8 +56301,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WJU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -56346,8 +56346,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -56391,8 +56391,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -56436,8 +56436,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -56481,8 +56481,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -56526,8 +56526,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -56571,8 +56571,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -56616,8 +56616,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -56661,8 +56661,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -56706,8 +56706,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WOA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -56747,11 +56747,11 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WOB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -56791,11 +56791,11 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WPA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -56839,8 +56839,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WPB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.407" />
@@ -56884,8 +56884,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WPD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -56929,8 +56929,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WPU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -56974,8 +56974,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WQA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -57017,8 +57017,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WQB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -57060,8 +57060,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WRA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -57097,8 +57097,8 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WRB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -57134,8 +57134,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -57179,8 +57179,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -57224,8 +57224,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WUA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -57265,11 +57265,11 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WUB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -57309,11 +57309,11 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WVA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -57369,8 +57369,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WVB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -57426,8 +57426,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WWA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -57483,8 +57483,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WWB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -57540,8 +57540,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WXA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -57577,8 +57577,8 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WXB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -57614,8 +57614,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WYA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -57671,8 +57671,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WYB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -57728,8 +57728,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WZA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -57769,11 +57769,11 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -57813,11 +57813,11 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WaA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -57853,8 +57853,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WaB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -57890,8 +57890,8 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WbA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.13" />
@@ -57935,8 +57935,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WbB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.227" />
@@ -57980,8 +57980,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WbD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -58025,8 +58025,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WbU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -58070,8 +58070,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WcA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.345" />
@@ -58115,8 +58115,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WcB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.244" />
@@ -58160,8 +58160,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WcD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -58205,8 +58205,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WcU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -58250,8 +58250,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WdA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -58287,8 +58287,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WdB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -58324,8 +58324,8 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -58369,8 +58369,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -58414,8 +58414,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WfA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -58457,8 +58457,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WfB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -58500,8 +58500,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H63" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -58545,8 +58545,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -58590,8 +58590,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WhA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -58633,8 +58633,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WhB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -58676,8 +58676,8 @@
       <Bond atomName1="C6M" atomName2="H2M" />
       <Bond atomName1="C6M" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WjA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.114" />
@@ -58721,8 +58721,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WjB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.413" />
@@ -58766,8 +58766,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WjD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -58811,8 +58811,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WjU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -58856,8 +58856,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -58901,8 +58901,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -58946,8 +58946,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -58991,8 +58991,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -59036,8 +59036,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -59081,8 +59081,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -59126,8 +59126,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -59171,8 +59171,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -59216,8 +59216,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WoA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -59257,11 +59257,11 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WoB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -59301,11 +59301,11 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WpA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -59349,8 +59349,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WpB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.407" />
@@ -59394,8 +59394,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WpD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -59439,8 +59439,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WpU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -59484,8 +59484,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WqA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -59527,8 +59527,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WqB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -59570,8 +59570,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H63" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WrA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -59607,8 +59607,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WrB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -59644,8 +59644,8 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -59689,8 +59689,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -59734,8 +59734,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WuA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -59775,11 +59775,11 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WuB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -59819,11 +59819,11 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WvA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -59879,8 +59879,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WvB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -59936,8 +59936,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WwA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -59993,8 +59993,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WwB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -60050,8 +60050,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WxA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -60087,8 +60087,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WxB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -60124,8 +60124,8 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WyA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -60181,8 +60181,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WyB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -60238,8 +60238,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="WzA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -60279,11 +60279,11 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WzB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -60323,11 +60323,11 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="XEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -60371,8 +60371,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -60416,8 +60416,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -60461,8 +60461,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -60506,8 +60506,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -60551,8 +60551,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -60596,8 +60596,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -60641,8 +60641,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -60686,8 +60686,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -60731,8 +60731,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -60776,8 +60776,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -60821,8 +60821,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -60866,8 +60866,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -60911,8 +60911,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -60956,8 +60956,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -61001,8 +61001,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -61046,8 +61046,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -61091,8 +61091,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -61136,8 +61136,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -61181,8 +61181,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -61226,8 +61226,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -61271,8 +61271,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -61316,8 +61316,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -61361,8 +61361,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -61406,8 +61406,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -61451,8 +61451,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -61496,8 +61496,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -61541,8 +61541,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="XtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -61586,8 +61586,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O6" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O6" />
     </Residue>
     <Residue name="YAA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -61623,8 +61623,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YAB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -61660,8 +61660,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YDA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -61697,8 +61697,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YDB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -61734,8 +61734,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -61779,8 +61779,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -61824,8 +61824,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YFA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -61867,8 +61867,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YFB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -61910,8 +61910,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -61955,8 +61955,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -62000,8 +62000,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YHA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -62043,8 +62043,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YHB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -62086,8 +62086,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -62131,8 +62131,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -62176,8 +62176,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -62221,8 +62221,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -62266,8 +62266,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -62311,8 +62311,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -62356,8 +62356,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -62401,8 +62401,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -62446,8 +62446,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YOA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -62487,11 +62487,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YOB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -62531,11 +62531,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YQA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -62577,8 +62577,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YQB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -62620,8 +62620,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YRA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -62657,8 +62657,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YRB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -62694,8 +62694,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -62739,8 +62739,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -62784,8 +62784,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YTV" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.47" />
@@ -62825,8 +62825,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YTv" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.428" />
@@ -62866,8 +62866,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YUA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -62907,11 +62907,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YUB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -62951,11 +62951,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YXA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -62991,8 +62991,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YXB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -63028,8 +63028,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YZA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -63069,11 +63069,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -63113,11 +63113,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YaA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -63153,8 +63153,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YaB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -63190,8 +63190,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YdA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -63227,8 +63227,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YdB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -63264,8 +63264,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -63309,8 +63309,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -63354,8 +63354,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YfA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -63397,8 +63397,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YfB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -63440,8 +63440,8 @@
       <Bond atomName1="C6" atomName2="H63" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -63485,8 +63485,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -63530,8 +63530,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YhA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -63573,8 +63573,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YhB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -63616,8 +63616,8 @@
       <Bond atomName1="C6M" atomName2="H1M" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -63661,8 +63661,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -63706,8 +63706,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -63751,8 +63751,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -63796,8 +63796,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -63841,8 +63841,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -63886,8 +63886,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -63931,8 +63931,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -63976,8 +63976,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YoA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -64017,11 +64017,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YoB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -64061,11 +64061,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YqA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -64107,8 +64107,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YqB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -64150,8 +64150,8 @@
       <Bond atomName1="C6" atomName2="H63" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YrA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -64187,8 +64187,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YrB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -64224,8 +64224,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -64269,8 +64269,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -64314,8 +64314,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YtV" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.47" />
@@ -64355,8 +64355,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="Ytv" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.428" />
@@ -64396,8 +64396,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H63" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YuA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -64437,11 +64437,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YuB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -64481,11 +64481,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YxA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -64521,8 +64521,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YxB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -64558,8 +64558,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="YzA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -64599,11 +64599,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YzB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -64643,11 +64643,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZAA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -64683,8 +64683,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZAB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -64720,8 +64720,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZAD" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.368" />
@@ -64757,8 +64757,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZAU" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.477" />
@@ -64794,8 +64794,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZDA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -64831,8 +64831,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZDB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -64868,8 +64868,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZDD" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.38" />
@@ -64905,8 +64905,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZDU" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.436" />
@@ -64942,8 +64942,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -64987,8 +64987,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -65032,8 +65032,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZFA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -65075,8 +65075,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZFB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -65118,8 +65118,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -65163,8 +65163,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -65208,8 +65208,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZHA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -65251,8 +65251,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZHB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -65294,8 +65294,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -65339,8 +65339,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -65384,8 +65384,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -65429,8 +65429,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -65474,8 +65474,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -65519,8 +65519,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -65564,8 +65564,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -65609,8 +65609,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -65654,8 +65654,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZOA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -65695,11 +65695,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZOB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -65739,11 +65739,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZQA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -65785,8 +65785,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZQB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -65828,8 +65828,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZRA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -65865,8 +65865,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZRB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -65902,8 +65902,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZRD" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.445" />
@@ -65939,8 +65939,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZRU" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.378" />
@@ -65976,8 +65976,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -66021,8 +66021,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -66066,8 +66066,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZUA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -66107,11 +66107,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZUB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -66151,11 +66151,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZXA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -66191,8 +66191,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZXB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -66228,8 +66228,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZXD" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.428" />
@@ -66265,8 +66265,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZXU" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.388" />
@@ -66302,8 +66302,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O2" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="ZZA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -66343,11 +66343,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
+      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O3" />
-      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="HYP" override="1">
       <Atom name="N" type="protein-N" charge="-0.2548" />
@@ -66413,8 +66413,8 @@
       <Bond atomName1="CA" atomName2="C" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="OD1" />
       <ExternalBond atomName="C" />
+      <ExternalBond atomName="OD1" />
     </Residue>
     <Residue name="CHYP" override="1">
       <Atom name="N" type="protein-N" charge="-0.28" />

--- a/amber/ffxml/GLYCAM_06j-1.xml
+++ b/amber/ffxml/GLYCAM_06j-1.xml
@@ -1,6 +1,6 @@
 <ForceField>
   <Info>
-    <DateGenerated>2021-07-13</DateGenerated>
+    <DateGenerated>2021-10-28</DateGenerated>
     <Source Source="glycam/leaprc.GLYCAM_06j-1" md5hash="a7359f8d717f92dba02d57d6e0c8f3f7" sourcePackage="AmberTools" sourcePackageVersion="20.15">glycam/leaprc.GLYCAM_06j-1</Source>
     <Reference>R. Kadirvelraj; O. C. Grant; I. J. Goldstein; H. C. Winter; H. Tateno; E. Fadda; R. J. Woods. Structure and binding analysis of Polyporus squamosus lectin in complex with the Neu5Ac&#945;2-6Gal&#946;1-4GlcNAc human- type influenza receptor. Glycobiology, 2011, 21, 973&#8211;984. M. L. DeMarco; R. J. Woods. From agonist to antagonist: Structure and dynamics of innate immune glycoprotein MD-2 upon recognition of variably acylated bacterial endotoxins. Mol. Immunol., 2011, 49, 124&#8211;133. B. L. Foley; M. B. Tessier; R. J. Woods. Carbohydrate force fields. WIREs Comput. Mol. Sci., 2012, 2, 652&#8211;697. E. Ficko-Blean; C. P. Stuart; M. D. Suits; M. Cid; M. Tessier; R. J. Woods; A. B. Boraston. Carbohy- drate Recognition by an Architecturally Complex &#945;-N-Acetylglucosaminidase from Clostridium perfrin- gens. PLoS ONE, 2012, 7, e33524.</Reference>
   </Info>
@@ -14570,10 +14570,10 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2OB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -14615,10 +14615,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2PA" override="1">
       <Atom name="O2" type="glycam-Os" charge="-0.388" />
@@ -15272,10 +15272,10 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2UB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -15317,10 +15317,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2XA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -15514,10 +15514,10 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2ZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -15559,10 +15559,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2aA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -17224,10 +17224,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2oB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -17269,10 +17269,10 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2pA" override="1">
       <Atom name="O2" type="glycam-Os" charge="-0.388" />
@@ -17926,10 +17926,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2uB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -17971,10 +17971,10 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2xA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -18168,10 +18168,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="2zB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -18213,10 +18213,10 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="3AA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -18528,9 +18528,9 @@
       <Bond atomName1="C4M" atomName2="H42" />
       <Bond atomName1="C4M" atomName2="H41" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C4N" />
       <ExternalBond atomName="O4N" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3BD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -19912,10 +19912,10 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3OB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -19957,10 +19957,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3PA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -20518,10 +20518,10 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3UB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -20563,10 +20563,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3VA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -21108,10 +21108,10 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3ZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -21153,10 +21153,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3aA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -21468,9 +21468,9 @@
       <Bond atomName1="C2M" atomName2="H22" />
       <Bond atomName1="C2M" atomName2="H23" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C4N" />
       <ExternalBond atomName="O4N" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3bD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -22852,10 +22852,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3oB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -22897,10 +22897,10 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3pA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -23458,10 +23458,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3uB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -23503,10 +23503,10 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3vA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -24048,10 +24048,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="3zB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -24093,10 +24093,10 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="4AA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -24966,12 +24966,12 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4HA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -25653,10 +25653,10 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4OB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -25698,10 +25698,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4PA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -26125,12 +26125,12 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4SB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -26206,12 +26206,12 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4TA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -26429,10 +26429,10 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4UB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -26474,10 +26474,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4VA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -26943,10 +26943,10 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4ZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -26988,10 +26988,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4aA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -27861,12 +27861,12 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4hA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -28548,10 +28548,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4oB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -28593,10 +28593,10 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4pA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -29020,12 +29020,12 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4sB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -29101,12 +29101,12 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4tA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -29324,10 +29324,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4uB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -29369,10 +29369,10 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4vA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -29838,10 +29838,10 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="4zB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -29883,10 +29883,10 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="5AD" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.368" />
@@ -34028,12 +34028,12 @@
       <Bond atomName1="O9" atomName2="H9O" />
       <Bond atomName1="O8" atomName2="H8O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="7SA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -34109,12 +34109,12 @@
       <Bond atomName1="O9" atomName2="H9O" />
       <Bond atomName1="O8" atomName2="H8O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="7SB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -34190,12 +34190,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="7gL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -34273,12 +34273,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="7sA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -34354,12 +34354,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="7sB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -34435,12 +34435,12 @@
       <Bond atomName1="O9" atomName2="H9O" />
       <Bond atomName1="O8" atomName2="H8O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="8GL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -34518,12 +34518,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="8SA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -34599,12 +34599,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="8SB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -34680,12 +34680,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="8gL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -34763,12 +34763,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="8sA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -34844,12 +34844,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="8sB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -34925,12 +34925,12 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="9GL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -35008,12 +35008,12 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O9" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O9" />
     </Residue>
     <Residue name="9SA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -35089,12 +35089,12 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O9" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O9" />
     </Residue>
     <Residue name="9SB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -35170,12 +35170,12 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O9" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O9" />
     </Residue>
     <Residue name="9gL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -35253,12 +35253,12 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O9" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O9" />
     </Residue>
     <Residue name="9sA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -35334,12 +35334,12 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O9" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O9" />
     </Residue>
     <Residue name="9sB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -35415,12 +35415,12 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O9" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O9" />
     </Residue>
     <Residue name="ACX" override="1">
       <Atom name="C1A" type="protein-C" charge="0.763" />
@@ -35507,7 +35507,6 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -35516,6 +35515,7 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ASA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -35585,7 +35585,6 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -35594,6 +35593,7 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ASB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -35663,7 +35663,6 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -35672,6 +35671,7 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="AgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -35743,7 +35743,6 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -35752,6 +35751,7 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="AsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -35821,7 +35821,6 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -35830,6 +35829,7 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="AsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -35899,7 +35899,6 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -35908,6 +35907,7 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="BGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -35981,7 +35981,6 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -35989,6 +35988,7 @@
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="O8" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="BSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -36060,7 +36060,6 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -36068,6 +36067,7 @@
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="O8" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="BSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -36139,7 +36139,6 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -36147,6 +36146,7 @@
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="BgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -36220,7 +36220,6 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -36228,6 +36227,7 @@
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="BsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -36299,7 +36299,6 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -36307,6 +36306,7 @@
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="BsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -36378,7 +36378,6 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -36386,6 +36385,7 @@
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="O8" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="CGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -36459,7 +36459,6 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -36467,6 +36466,7 @@
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="CSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -36538,7 +36538,6 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -36546,6 +36545,7 @@
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="CSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -36617,7 +36617,6 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -36625,6 +36624,7 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="CgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -36698,7 +36698,6 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -36706,6 +36705,7 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="CsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -36777,7 +36777,6 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -36785,6 +36784,7 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="CsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -36856,7 +36856,6 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -36864,6 +36863,7 @@
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="DGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -36937,7 +36937,6 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -36945,6 +36944,7 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="DSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -37016,7 +37016,6 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -37024,6 +37023,7 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="DSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -37095,7 +37095,6 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -37103,6 +37102,7 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="DgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -37176,7 +37176,6 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -37184,6 +37183,7 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="DsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -37255,7 +37255,6 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -37263,6 +37262,7 @@
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="DsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -37334,7 +37334,6 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -37342,6 +37341,7 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="EGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -37415,7 +37415,6 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -37423,6 +37422,7 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ESA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -37494,7 +37494,6 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -37502,6 +37501,7 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ESB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -37573,7 +37573,6 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -37581,6 +37580,7 @@
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="EgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -37654,7 +37654,6 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -37662,6 +37661,7 @@
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="EsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -37733,7 +37733,6 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
@@ -37741,6 +37740,7 @@
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="EsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -37812,7 +37812,6 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
@@ -37820,6 +37819,7 @@
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="FGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -37895,13 +37895,13 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="FSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -37975,13 +37975,13 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="FSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -38055,13 +38055,13 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="FgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -38137,13 +38137,13 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="FsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -38217,13 +38217,13 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="FsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -38297,13 +38297,13 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O8" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O8" />
     </Residue>
     <Residue name="GGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -38379,13 +38379,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O8" atomName2="H8O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="GSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -38459,13 +38459,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O8" atomName2="H8O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="GSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -38539,13 +38539,13 @@
       <Bond atomName1="C9" atomName2="H9R" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="GgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -38621,13 +38621,13 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="GsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -38701,13 +38701,13 @@
       <Bond atomName1="C9" atomName2="H9S" />
       <Bond atomName1="C9" atomName2="O9" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="GsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -38781,13 +38781,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O8" atomName2="H8O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O9" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="HGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -38863,13 +38863,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="HSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -38943,13 +38943,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="HSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -39023,13 +39023,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="HgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -39105,13 +39105,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="HsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -39185,13 +39185,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="HsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -39265,13 +39265,13 @@
       <Bond atomName1="C9" atomName2="O9" />
       <Bond atomName1="O9" atomName2="H9O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O7" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
       <ExternalBond atomName="O8" />
+      <ExternalBond atomName="O7" />
     </Residue>
     <Residue name="IGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -39347,13 +39347,13 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ISA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -39427,13 +39427,13 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ISB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -39507,13 +39507,13 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="IgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -39589,13 +39589,13 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="IsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -39669,13 +39669,13 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="IsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -39749,13 +39749,13 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O9" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="JGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -39831,13 +39831,13 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="JSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -39911,13 +39911,13 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="JSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -39991,13 +39991,13 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="JgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -40073,13 +40073,13 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="JsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -40153,13 +40153,13 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="JsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -40233,13 +40233,13 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O8" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="KGL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -40315,13 +40315,13 @@
       <Bond atomName1="CME" atomName2="OHG" />
       <Bond atomName1="OHG" atomName2="HOG" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="KSA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -40395,13 +40395,13 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="KSB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -40475,13 +40475,13 @@
       <Bond atomName1="C3" atomName2="H3E" />
       <Bond atomName1="C3" atomName2="H3A" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="KgL" override="1">
       <Atom name="C2" type="glycam-Cy" charge="-0.014" />
@@ -40557,13 +40557,13 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="KsA" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.237" />
@@ -40637,13 +40637,13 @@
       <Bond atomName1="C3" atomName2="H3A" />
       <Bond atomName1="C3" atomName2="H3E" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="KsB" override="1">
       <Atom name="C2" type="glycam-Cy" charge="0.09" />
@@ -40717,13 +40717,13 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="C1" />
       <ExternalBond atomName="O1A" />
       <ExternalBond atomName="O1B" />
       <ExternalBond atomName="O7" />
       <ExternalBond atomName="C5N" />
       <ExternalBond atomName="O5N" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="MEX" override="1">
       <Atom name="CH3" type="glycam-Cg" charge="0.233" />
@@ -40762,8 +40762,8 @@
       <Bond atomName1="ND2" atomName2="HD21" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="ND2" />
+      <ExternalBond atomName="C" />
     </Residue>
     <Residue name="OLS" override="1">
       <Atom name="N" type="protein-N" charge="-0.4157" />
@@ -40786,8 +40786,8 @@
       <Bond atomName1="CB" atomName2="OG" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="OG" />
+      <ExternalBond atomName="C" />
     </Residue>
     <Residue name="OLT" override="1">
       <Atom name="N" type="protein-N" charge="-0.4157" />
@@ -40816,8 +40816,8 @@
       <Bond atomName1="CG2" atomName2="HG23" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="OG1" />
+      <ExternalBond atomName="C" />
     </Residue>
     <Residue name="OME" override="1">
       <Atom name="H1" type="protein-H1" charge="0.0" />
@@ -40829,9 +40829,7 @@
       <Bond atomName1="CH3" atomName2="H2" />
       <Bond atomName1="CH3" atomName2="H3" />
       <Bond atomName1="CH3" atomName2="O" />
-      <ExternalBond atomName="H1" />
       <ExternalBond atomName="O" />
-      <ExternalBond atomName="CH3" />
     </Residue>
     <Residue name="PEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -40871,10 +40869,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -40914,10 +40912,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -40957,10 +40955,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -41000,10 +40998,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -41043,10 +41041,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -41086,10 +41084,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -41129,10 +41127,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -41172,10 +41170,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -41215,10 +41213,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -41258,10 +41256,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -41301,10 +41299,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -41344,10 +41342,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -41387,10 +41385,10 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -41430,10 +41428,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -41473,10 +41471,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -41516,10 +41514,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -41559,10 +41557,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -41602,10 +41600,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -41645,10 +41643,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -41688,10 +41686,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -41731,10 +41729,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -41774,10 +41772,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -41817,10 +41815,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -41860,10 +41858,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -41903,10 +41901,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -41946,10 +41944,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -41989,10 +41987,10 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="PtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -42032,10 +42030,10 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="QBD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -42077,9 +42075,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QBU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -42121,9 +42119,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QCD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -42165,9 +42163,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QCU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -42209,9 +42207,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -42253,9 +42251,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -42297,9 +42295,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -42341,9 +42339,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -42385,9 +42383,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QJD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -42429,9 +42427,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QJU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -42473,9 +42471,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -42517,9 +42515,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -42561,9 +42559,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -42605,9 +42603,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -42649,9 +42647,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -42693,9 +42691,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -42737,9 +42735,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -42781,9 +42779,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -42825,9 +42823,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QPD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -42869,9 +42867,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QPU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -42913,9 +42911,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -42957,9 +42955,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -43001,9 +42999,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QVA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -43057,9 +43055,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QVB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -43113,9 +43111,9 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QWA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -43169,9 +43167,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QWB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -43225,9 +43223,9 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QYA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -43281,9 +43279,9 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QYB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -43337,9 +43335,9 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QbD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -43381,9 +43379,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QbU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -43425,9 +43423,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QcD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -43469,9 +43467,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QcU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -43513,9 +43511,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -43557,9 +43555,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -43601,9 +43599,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -43645,9 +43643,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -43689,9 +43687,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QjD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -43733,9 +43731,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QjU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -43777,9 +43775,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -43821,9 +43819,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -43865,9 +43863,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -43909,9 +43907,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -43953,9 +43951,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -43997,9 +43995,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -44041,9 +44039,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -44085,9 +44083,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -44129,9 +44127,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QpD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -44173,9 +44171,9 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QpU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -44217,9 +44215,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -44261,9 +44259,9 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -44305,9 +44303,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QvA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -44361,9 +44359,9 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QvB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -44417,9 +44415,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QwA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -44473,9 +44471,9 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QwB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -44529,9 +44527,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QyA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -44585,9 +44583,9 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="QyB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -44641,9 +44639,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="REA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -44685,9 +44683,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="REB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -44729,9 +44727,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -44773,9 +44771,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -44817,9 +44815,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -44861,9 +44859,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -44905,9 +44903,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -44949,9 +44947,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -44993,9 +44991,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -45037,9 +45035,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -45081,9 +45079,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -45125,9 +45123,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -45169,15 +45167,14 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ROH" override="1">
       <Atom name="HO1" type="glycam-Ho" charge="0.445" />
       <Atom name="O1" type="glycam-Oh" charge="-0.639" />
       <Bond atomName1="HO1" atomName2="O1" />
-      <ExternalBond atomName="HO1" />
       <ExternalBond atomName="O1" />
     </Residue>
     <Residue name="RTA" override="1">
@@ -45220,9 +45217,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -45264,9 +45261,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ReA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -45308,9 +45305,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ReB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -45352,9 +45349,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -45396,9 +45393,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -45440,9 +45437,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -45484,9 +45481,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -45528,9 +45525,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -45572,9 +45569,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -45616,9 +45613,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -45660,9 +45657,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -45704,9 +45701,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -45748,9 +45745,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -45792,9 +45789,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -45836,9 +45833,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="RtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -45880,9 +45877,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -45924,9 +45921,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -45968,9 +45965,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -46012,9 +46009,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -46056,9 +46053,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -46100,9 +46097,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -46144,9 +46141,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -46188,9 +46185,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -46232,9 +46229,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -46276,9 +46273,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -46320,9 +46317,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -46364,9 +46361,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -46408,9 +46405,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SO3" override="1">
       <Atom name="S1" type="protein-S" charge="1.245" />
@@ -46421,9 +46418,6 @@
       <Bond atomName1="S1" atomName2="O2" />
       <Bond atomName1="S1" atomName2="O3" />
       <ExternalBond atomName="S1" />
-      <ExternalBond atomName="O1" />
-      <ExternalBond atomName="O2" />
-      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="STA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -46465,9 +46459,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="STB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -46509,9 +46503,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -46553,9 +46547,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -46597,9 +46591,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -46641,9 +46635,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -46685,9 +46679,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -46729,9 +46723,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -46773,9 +46767,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -46817,9 +46811,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -46861,9 +46855,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -46905,9 +46899,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -46949,9 +46943,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -46993,9 +46987,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="SnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -47037,9 +47031,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="StA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -47081,9 +47075,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="StB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -47125,9 +47119,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TAA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -47161,9 +47155,9 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TAB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -47197,9 +47191,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TBT" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.021" />
@@ -47229,7 +47223,6 @@
       <Bond atomName1="C4" atomName2="H7" />
       <Bond atomName1="C4" atomName2="H8" />
       <Bond atomName1="C4" atomName2="H9" />
-      <ExternalBond atomName="C2" />
       <ExternalBond atomName="O1" />
     </Residue>
     <Residue name="TDA" override="1">
@@ -47264,9 +47257,9 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TDB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -47300,9 +47293,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -47344,9 +47337,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -47388,9 +47381,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TFA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -47430,9 +47423,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TFB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -47472,9 +47465,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -47516,9 +47509,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -47560,9 +47553,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="THA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -47602,9 +47595,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="THB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -47644,9 +47637,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -47688,9 +47681,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -47732,9 +47725,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -47776,9 +47769,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -47820,9 +47813,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -47864,9 +47857,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -47908,9 +47901,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -47952,9 +47945,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -47996,9 +47989,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TOA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -48036,12 +48029,12 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TOB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -48079,12 +48072,12 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TQA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -48124,9 +48117,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TQB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -48166,9 +48159,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TRA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -48202,9 +48195,9 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TRB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -48238,9 +48231,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -48282,9 +48275,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -48326,9 +48319,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TUA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -48366,12 +48359,12 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TUB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -48409,12 +48402,12 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TXA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -48448,9 +48441,9 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TXB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -48484,9 +48477,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TZA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -48524,12 +48517,12 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -48567,12 +48560,12 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TaA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -48606,9 +48599,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TaB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -48642,9 +48635,9 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TdA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -48678,9 +48671,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TdB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -48714,9 +48707,9 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -48758,9 +48751,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -48802,9 +48795,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TfA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -48844,9 +48837,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TfB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -48886,9 +48879,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H63" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -48930,9 +48923,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -48974,9 +48967,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ThA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -49016,9 +49009,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ThB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -49058,9 +49051,9 @@
       <Bond atomName1="C6M" atomName2="H2M" />
       <Bond atomName1="C6M" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -49102,9 +49095,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -49146,9 +49139,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -49190,9 +49183,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -49234,9 +49227,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -49278,9 +49271,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -49322,9 +49315,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -49366,9 +49359,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -49410,9 +49403,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ToA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -49450,12 +49443,12 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ToB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -49493,12 +49486,12 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TqA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -49538,9 +49531,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TqB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -49580,9 +49573,9 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H63" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TrA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -49616,9 +49609,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TrB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -49652,9 +49645,9 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -49696,9 +49689,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -49740,9 +49733,9 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TuA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -49780,12 +49773,12 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TuB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -49823,12 +49816,12 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TxA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -49862,9 +49855,9 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TxB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -49898,9 +49891,9 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TzA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -49938,12 +49931,12 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="TzB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -49981,12 +49974,12 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="UBD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -50030,8 +50023,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UBU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -50075,8 +50068,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UCD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -50120,8 +50113,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UCU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -50165,8 +50158,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -50210,8 +50203,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -50255,8 +50248,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -50300,8 +50293,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -50345,8 +50338,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UJD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -50390,8 +50383,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UJU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -50435,8 +50428,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -50480,8 +50473,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -50525,8 +50518,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ULA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -50570,8 +50563,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="ULB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -50615,8 +50608,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -50660,8 +50653,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -50705,8 +50698,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -50750,8 +50743,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -50795,8 +50788,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UPD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -50840,8 +50833,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UPU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -50885,8 +50878,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -50930,8 +50923,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -50975,8 +50968,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UVA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -51032,8 +51025,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UVB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -51089,8 +51082,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UWA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -51146,8 +51139,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UWB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -51203,8 +51196,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UYA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -51260,8 +51253,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UYB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -51317,8 +51310,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UbD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -51362,8 +51355,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UbU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -51407,8 +51400,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UcD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -51452,8 +51445,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UcU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -51497,8 +51490,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -51542,8 +51535,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -51587,8 +51580,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -51632,8 +51625,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -51677,8 +51670,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UjD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -51722,8 +51715,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UjU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -51767,8 +51760,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -51812,8 +51805,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -51857,8 +51850,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -51902,8 +51895,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -51947,8 +51940,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -51992,8 +51985,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -52037,8 +52030,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -52082,8 +52075,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -52127,8 +52120,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UpD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -52172,8 +52165,8 @@
       <Bond atomName1="C3" atomName2="O3" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UpU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -52217,8 +52210,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -52262,8 +52255,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -52307,8 +52300,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UvA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -52364,8 +52357,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UvB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -52421,8 +52414,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UwA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -52478,8 +52471,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UwB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -52535,8 +52528,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UyA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -52592,8 +52585,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="UyB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -52649,8 +52642,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="O6" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O4" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O4" />
     </Residue>
     <Residue name="VBD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -52694,8 +52687,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VBU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -52739,8 +52732,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VCD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -52784,8 +52777,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VCU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -52829,8 +52822,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -52874,8 +52867,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -52919,8 +52912,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -52964,8 +52957,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -53009,8 +53002,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VJD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -53054,8 +53047,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VJU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -53099,8 +53092,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -53144,8 +53137,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -53189,8 +53182,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -53234,8 +53227,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -53279,8 +53272,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -53324,8 +53317,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -53369,8 +53362,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -53414,8 +53407,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -53459,8 +53452,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VPD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -53504,8 +53497,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VPU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -53549,8 +53542,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -53594,8 +53587,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -53639,8 +53632,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VVA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -53696,8 +53689,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VVB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -53753,8 +53746,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VWA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -53810,8 +53803,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VWB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -53867,8 +53860,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VYA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -53924,8 +53917,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VYB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -53981,8 +53974,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VbD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -54026,8 +54019,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VbU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -54071,8 +54064,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VcD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -54116,8 +54109,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VcU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -54161,8 +54154,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -54206,8 +54199,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -54251,8 +54244,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -54296,8 +54289,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -54341,8 +54334,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VjD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -54386,8 +54379,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VjU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -54431,8 +54424,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -54476,8 +54469,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -54521,8 +54514,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -54566,8 +54559,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -54611,8 +54604,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -54656,8 +54649,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -54701,8 +54694,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -54746,8 +54739,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -54791,8 +54784,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VpD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -54836,8 +54829,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VpU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -54881,8 +54874,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -54926,8 +54919,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -54971,8 +54964,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VvA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -55028,8 +55021,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VvB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -55085,8 +55078,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VwA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -55142,8 +55135,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VwB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -55199,8 +55192,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VyA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -55256,8 +55249,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="VyB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -55313,8 +55306,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WAA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -55350,8 +55343,8 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WAB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -55387,8 +55380,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WBA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.13" />
@@ -55432,8 +55425,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WBB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.227" />
@@ -55477,8 +55470,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WBD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -55522,8 +55515,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WBU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -55567,8 +55560,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WCA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.345" />
@@ -55612,8 +55605,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WCB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.244" />
@@ -55657,8 +55650,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WCD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -55702,8 +55695,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WCU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -55747,8 +55740,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WDA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -55784,8 +55777,8 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WDB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -55821,8 +55814,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -55866,8 +55859,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -55911,8 +55904,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WFA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -55954,8 +55947,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WFB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -55997,8 +55990,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -56042,8 +56035,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -56087,8 +56080,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WHA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -56130,8 +56123,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WHB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -56173,8 +56166,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WJA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.114" />
@@ -56218,8 +56211,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WJB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.413" />
@@ -56263,8 +56256,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WJD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -56308,8 +56301,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WJU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -56353,8 +56346,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -56398,8 +56391,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -56443,8 +56436,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -56488,8 +56481,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -56533,8 +56526,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -56578,8 +56571,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -56623,8 +56616,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -56668,8 +56661,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -56713,8 +56706,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WOA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -56754,11 +56747,11 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WOB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -56798,11 +56791,11 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WPA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -56846,8 +56839,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WPB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.407" />
@@ -56891,8 +56884,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WPD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -56936,8 +56929,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WPU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -56981,8 +56974,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WQA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -57024,8 +57017,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WQB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -57067,8 +57060,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WRA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -57104,8 +57097,8 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WRB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -57141,8 +57134,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -57186,8 +57179,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -57231,8 +57224,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WUA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -57272,11 +57265,11 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WUB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -57316,11 +57309,11 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WVA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -57376,8 +57369,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WVB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -57433,8 +57426,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WWA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -57490,8 +57483,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WWB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -57547,8 +57540,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WXA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -57584,8 +57577,8 @@
       <Bond atomName1="C5" atomName2="H5A" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WXB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -57621,8 +57614,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WYA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -57678,8 +57671,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WYB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -57735,8 +57728,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WZA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -57776,11 +57769,11 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -57820,11 +57813,11 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WaA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -57860,8 +57853,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WaB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -57897,8 +57890,8 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WbA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.13" />
@@ -57942,8 +57935,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WbB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.227" />
@@ -57987,8 +57980,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WbD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.241" />
@@ -58032,8 +58025,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WbU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.247" />
@@ -58077,8 +58070,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WcA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.345" />
@@ -58122,8 +58115,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WcB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.244" />
@@ -58167,8 +58160,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WcD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.284" />
@@ -58212,8 +58205,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WcU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.239" />
@@ -58257,8 +58250,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WdA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -58294,8 +58287,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WdB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -58331,8 +58324,8 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -58376,8 +58369,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -58421,8 +58414,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WfA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -58464,8 +58457,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WfB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -58507,8 +58500,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H63" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -58552,8 +58545,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -58597,8 +58590,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WhA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -58640,8 +58633,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WhB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -58683,8 +58676,8 @@
       <Bond atomName1="C6M" atomName2="H2M" />
       <Bond atomName1="C6M" atomName2="H1M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WjA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.114" />
@@ -58728,8 +58721,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WjB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.413" />
@@ -58773,8 +58766,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WjD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.192" />
@@ -58818,8 +58811,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WjU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.351" />
@@ -58863,8 +58856,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -58908,8 +58901,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -58953,8 +58946,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -58998,8 +58991,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -59043,8 +59036,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -59088,8 +59081,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -59133,8 +59126,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -59178,8 +59171,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -59223,8 +59216,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WoA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -59264,11 +59257,11 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WoB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -59308,11 +59301,11 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WpA" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.417" />
@@ -59356,8 +59349,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WpB" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.407" />
@@ -59401,8 +59394,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WpD" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.324" />
@@ -59446,8 +59439,8 @@
       <Bond atomName1="C3" atomName2="H3" />
       <Bond atomName1="C3" atomName2="O3" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WpU" override="1">
       <Atom name="C2" type="glycam-Cg" charge="0.288" />
@@ -59491,8 +59484,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C2" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WqA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -59534,8 +59527,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WqB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -59577,8 +59570,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H63" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WrA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -59614,8 +59607,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WrB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -59651,8 +59644,8 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -59696,8 +59689,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -59741,8 +59734,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WuA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -59782,11 +59775,11 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WuB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -59826,11 +59819,11 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WvA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.389" />
@@ -59886,8 +59879,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WvB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -59943,8 +59936,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WwA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.4621" />
@@ -60000,8 +59993,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WwB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.387" />
@@ -60057,8 +60050,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WxA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -60094,8 +60087,8 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WxB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -60131,8 +60124,8 @@
       <Bond atomName1="C5" atomName2="H5E" />
       <Bond atomName1="C5" atomName2="O5" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WyA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.468" />
@@ -60188,8 +60181,8 @@
       <Bond atomName1="CME" atomName2="H2M" />
       <Bond atomName1="CME" atomName2="H3M" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WyB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.287" />
@@ -60245,8 +60238,8 @@
       <Bond atomName1="C6" atomName2="O6" />
       <Bond atomName1="O6" atomName2="H6O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WzA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -60286,11 +60279,11 @@
       <Bond atomName1="C2" atomName2="O2" />
       <Bond atomName1="O2" atomName2="H2O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="WzB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -60330,11 +60323,11 @@
       <Bond atomName1="C6" atomName2="O6A" />
       <Bond atomName1="C6" atomName2="O6B" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O3" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O3" />
     </Residue>
     <Residue name="XEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -60378,8 +60371,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -60423,8 +60416,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -60468,8 +60461,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -60513,8 +60506,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -60558,8 +60551,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -60603,8 +60596,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -60648,8 +60641,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -60693,8 +60686,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -60738,8 +60731,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -60783,8 +60776,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -60828,8 +60821,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -60873,8 +60866,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -60918,8 +60911,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -60963,8 +60956,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -61008,8 +61001,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -61053,8 +61046,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -61098,8 +61091,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -61143,8 +61136,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -61188,8 +61181,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -61233,8 +61226,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -61278,8 +61271,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -61323,8 +61316,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -61368,8 +61361,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -61413,8 +61406,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -61458,8 +61451,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -61503,8 +61496,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -61548,8 +61541,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="XtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -61593,8 +61586,8 @@
       <Bond atomName1="O4" atomName2="H4O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O6" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YAA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -61630,8 +61623,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YAB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -61667,8 +61660,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YDA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -61704,8 +61697,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YDB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -61741,8 +61734,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -61786,8 +61779,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -61831,8 +61824,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YFA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -61874,8 +61867,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YFB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -61917,8 +61910,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -61962,8 +61955,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -62007,8 +62000,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YHA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -62050,8 +62043,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YHB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -62093,8 +62086,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -62138,8 +62131,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -62183,8 +62176,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -62228,8 +62221,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -62273,8 +62266,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -62318,8 +62311,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -62363,8 +62356,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -62408,8 +62401,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -62453,8 +62446,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YOA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -62494,11 +62487,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YOB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -62538,11 +62531,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YQA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -62584,8 +62577,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YQB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -62627,8 +62620,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YRA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -62664,8 +62657,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YRB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -62701,8 +62694,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -62746,8 +62739,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -62791,8 +62784,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YTV" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.47" />
@@ -62832,8 +62825,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H61" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YTv" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.428" />
@@ -62873,8 +62866,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YUA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -62914,11 +62907,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YUB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -62958,11 +62951,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YXA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -62998,8 +62991,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YXB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -63035,8 +63028,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YZA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -63076,11 +63069,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YZB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -63120,11 +63113,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YaA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -63160,8 +63153,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YaB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -63197,8 +63190,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YdA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -63234,8 +63227,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YdB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -63271,8 +63264,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YeA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -63316,8 +63309,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YeB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -63361,8 +63354,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YfA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -63404,8 +63397,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YfB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -63447,8 +63440,8 @@
       <Bond atomName1="C6" atomName2="H63" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YgA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -63492,8 +63485,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YgB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -63537,8 +63530,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YhA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -63580,8 +63573,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YhB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -63623,8 +63616,8 @@
       <Bond atomName1="C6M" atomName2="H1M" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YkA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -63668,8 +63661,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YkB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -63713,8 +63706,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YlA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -63758,8 +63751,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YlB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -63803,8 +63796,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YmA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -63848,8 +63841,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YmB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -63893,8 +63886,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YnA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -63938,8 +63931,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YnB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -63983,8 +63976,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YoA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -64024,11 +64017,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YoB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -64068,11 +64061,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YqA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -64114,8 +64107,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YqB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -64157,8 +64150,8 @@
       <Bond atomName1="C6" atomName2="H63" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YrA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -64194,8 +64187,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YrB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -64231,8 +64224,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YtA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -64276,8 +64269,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YtB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -64321,8 +64314,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YtV" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.47" />
@@ -64362,8 +64355,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="Ytv" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.428" />
@@ -64403,8 +64396,8 @@
       <Bond atomName1="C6" atomName2="H62" />
       <Bond atomName1="C6" atomName2="H63" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YuA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -64444,11 +64437,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YuB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -64488,11 +64481,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YxA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -64528,8 +64521,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YxB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -64565,8 +64558,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YzA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -64606,11 +64599,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="YzB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.251" />
@@ -64650,11 +64643,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O3" atomName2="H3O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O4" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZAA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -64690,8 +64683,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZAB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.379" />
@@ -64727,8 +64720,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZAD" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.368" />
@@ -64764,8 +64757,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZAU" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.477" />
@@ -64801,8 +64794,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZDA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -64838,8 +64831,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZDB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.448" />
@@ -64875,8 +64868,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZDD" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.38" />
@@ -64912,8 +64905,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZDU" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.436" />
@@ -64949,8 +64942,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZEA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.48" />
@@ -64994,8 +64987,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZEB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -65039,8 +65032,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZFA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.399" />
@@ -65082,8 +65075,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZFB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.418" />
@@ -65125,8 +65118,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZGA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.509" />
@@ -65170,8 +65163,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZGB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.384" />
@@ -65215,8 +65208,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZHA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.394" />
@@ -65258,8 +65251,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZHB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.381" />
@@ -65301,8 +65294,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZKA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.473" />
@@ -65346,8 +65339,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZKB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.449" />
@@ -65391,8 +65384,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZLA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -65436,8 +65429,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZLB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.374" />
@@ -65481,8 +65474,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZMA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.433" />
@@ -65526,8 +65519,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZMB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.314" />
@@ -65571,8 +65564,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZNA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.478" />
@@ -65616,8 +65609,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZNB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.422" />
@@ -65661,8 +65654,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZOA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.305" />
@@ -65702,11 +65695,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZOB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.301" />
@@ -65746,11 +65739,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZQA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.465" />
@@ -65792,8 +65785,8 @@
       <Bond atomName1="C6" atomName2="H61" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZQB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.391" />
@@ -65835,8 +65828,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZRA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.488" />
@@ -65872,8 +65865,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZRB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.481" />
@@ -65909,8 +65902,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZRD" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.445" />
@@ -65946,8 +65939,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZRU" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.378" />
@@ -65983,8 +65976,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZTA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.456" />
@@ -66028,8 +66021,8 @@
       <Bond atomName1="O6" atomName2="H6O" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZTB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.306" />
@@ -66073,8 +66066,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZUA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.363" />
@@ -66114,11 +66107,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZUB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.278" />
@@ -66158,11 +66151,11 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZXA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.482" />
@@ -66198,8 +66191,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZXB" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.248" />
@@ -66235,8 +66228,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZXD" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.428" />
@@ -66272,8 +66265,8 @@
       <Bond atomName1="C5" atomName2="O5" />
       <Bond atomName1="O5" atomName2="H5O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZXU" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.388" />
@@ -66309,8 +66302,8 @@
       <Bond atomName1="C2" atomName2="H2" />
       <Bond atomName1="C2" atomName2="O2" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="ZZA" override="1">
       <Atom name="C1" type="glycam-Cg" charge="0.398" />
@@ -66350,11 +66343,11 @@
       <Bond atomName1="C6" atomName2="O6B" />
       <Bond atomName1="O4" atomName2="H4O" />
       <ExternalBond atomName="C1" />
-      <ExternalBond atomName="O2" />
       <ExternalBond atomName="C6" />
       <ExternalBond atomName="O6A" />
       <ExternalBond atomName="O6B" />
       <ExternalBond atomName="O3" />
+      <ExternalBond atomName="O2" />
     </Residue>
     <Residue name="HYP" override="1">
       <Atom name="N" type="protein-N" charge="-0.2548" />
@@ -66389,9 +66382,6 @@
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
       <ExternalBond atomName="C" />
-      <ExternalBond atomName="CG" />
-      <ExternalBond atomName="OD1" />
-      <ExternalBond atomName="HOD" />
     </Residue>
     <Residue name="OLP" override="1">
       <Atom name="N" type="protein-N" charge="-0.2548" />
@@ -66424,7 +66414,6 @@
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
       <ExternalBond atomName="C" />
-      <ExternalBond atomName="CG" />
     </Residue>
     <Residue name="CHYP" override="1">
       <Atom name="N" type="protein-N" charge="-0.28" />
@@ -66460,10 +66449,6 @@
       <Bond atomName1="C" atomName2="O" />
       <Bond atomName1="C" atomName2="OXT" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
-      <ExternalBond atomName="CG" />
-      <ExternalBond atomName="OD1" />
-      <ExternalBond atomName="HD1" />
     </Residue>
     <Residue name="CNLN" override="1">
       <Atom name="N" type="protein-N" charge="-0.3821" />
@@ -66494,7 +66479,6 @@
       <Bond atomName1="C" atomName2="O" />
       <Bond atomName1="C" atomName2="OXT" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="ND2" />
     </Residue>
     <Residue name="COLP" override="1">
@@ -66529,8 +66513,6 @@
       <Bond atomName1="C" atomName2="O" />
       <Bond atomName1="C" atomName2="OXT" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
-      <ExternalBond atomName="CG" />
     </Residue>
     <Residue name="COLS" override="1">
       <Atom name="N" type="protein-N" charge="-0.3821" />
@@ -66555,7 +66537,6 @@
       <Bond atomName1="C" atomName2="O" />
       <Bond atomName1="C" atomName2="OXT" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="OG" />
     </Residue>
     <Residue name="COLT" override="1">
@@ -66587,7 +66568,6 @@
       <Bond atomName1="C" atomName2="O" />
       <Bond atomName1="C" atomName2="OXT" />
       <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="OG1" />
     </Residue>
     <Residue name="NHYP" override="1">
@@ -66625,11 +66605,7 @@
       <Bond atomName1="CA" atomName2="HA" />
       <Bond atomName1="CA" atomName2="C" />
       <Bond atomName1="C" atomName2="O" />
-      <ExternalBond atomName="N" />
       <ExternalBond atomName="C" />
-      <ExternalBond atomName="CG" />
-      <ExternalBond atomName="OD1" />
-      <ExternalBond atomName="HD1" />
     </Residue>
     <Residue name="NNLN" override="1">
       <Atom name="N" type="protein-N3" charge="0.1801" />
@@ -66661,9 +66637,8 @@
       <Bond atomName1="CG" atomName2="ND2" />
       <Bond atomName1="ND2" atomName2="HD21" />
       <Bond atomName1="C" atomName2="O" />
-      <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="ND2" />
+      <ExternalBond atomName="C" />
     </Residue>
     <Residue name="NOLP" override="1">
       <Atom name="N" type="protein-N3" charge="-0.202" />
@@ -66698,9 +66673,7 @@
       <Bond atomName1="CA" atomName2="HA" />
       <Bond atomName1="CA" atomName2="C" />
       <Bond atomName1="C" atomName2="O" />
-      <ExternalBond atomName="N" />
       <ExternalBond atomName="C" />
-      <ExternalBond atomName="CG" />
     </Residue>
     <Residue name="NOLS" override="1">
       <Atom name="N" type="protein-N3" charge="0.1849" />
@@ -66726,9 +66699,8 @@
       <Bond atomName1="CB" atomName2="HB3" />
       <Bond atomName1="CB" atomName2="OG" />
       <Bond atomName1="C" atomName2="O" />
-      <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="OG" />
+      <ExternalBond atomName="C" />
     </Residue>
     <Residue name="NOLT" override="1">
       <Atom name="N" type="protein-N3" charge="0.1812" />
@@ -66760,9 +66732,8 @@
       <Bond atomName1="CG2" atomName2="HG22" />
       <Bond atomName1="CG2" atomName2="HG23" />
       <Bond atomName1="C" atomName2="O" />
-      <ExternalBond atomName="N" />
-      <ExternalBond atomName="C" />
       <ExternalBond atomName="OG1" />
+      <ExternalBond atomName="C" />
     </Residue>
   </Residues>
   <HarmonicBondForce>
@@ -67918,12 +67889,29 @@ for force in sys.getForces():
           force.setExceptionParameters(i, p1, p2, atom_charges[p1]*atom_charges[p2], (atom_sigmas[p1]+atom_sigmas[p2])/2, unit.sqrt(atom_epsilons[p1]*atom_epsilons[p2]))
 </Script>
 <InitializationScript> 
+from openmm.app.internal import compiled
+
 class GlycamTemplateMatcher(object):
+
   def __init__(self, glycam_residues):
     self.glycam_residues = glycam_residues
-  def __call__(self, ff, residue):
+
+  def __call__(self, ff, residue, bondedToAtom, ignoreExternalBonds, ignoreExtraParticles):
     if residue.name in self.glycam_residues:
-      return ff._templates[residue.name]
+      template = ff._templates[residue.name]
+      if compiled.matchResidueToTemplate(residue, template, bondedToAtom, ignoreExternalBonds, ignoreExtraParticles) is not None:
+        return template
+
+      # The residue doesn't actually match the template with the same name.  Try the terminal variants.
+
+      if 'N'+residue.name in self.glycam_residues:
+        template = ff._templates['N'+residue.name]
+        if compiled.matchResidueToTemplate(residue, template, bondedToAtom, ignoreExternalBonds, ignoreExtraParticles) is not None:
+          return template
+      if 'C'+residue.name in self.glycam_residues:
+        template = ff._templates['C'+residue.name]
+        if compiled.matchResidueToTemplate(residue, template, bondedToAtom, ignoreExternalBonds, ignoreExtraParticles) is not None:
+          return template
     return None
 
 glycam_residues = set()
@@ -67931,4 +67919,4 @@ for residue in tree.getroot().find('Residues').findall('Residue'):
   glycam_residues.add(residue.get('name'))
 self.registerTemplateMatcher(GlycamTemplateMatcher(glycam_residues))
 
-    </InitializationScript></ForceField>
+</InitializationScript></ForceField>

--- a/amber/ffxml/GLYCAM_06j-1.xml
+++ b/amber/ffxml/GLYCAM_06j-1.xml
@@ -66413,6 +66413,7 @@
       <Bond atomName1="CA" atomName2="C" />
       <Bond atomName1="C" atomName2="O" />
       <ExternalBond atomName="N" />
+      <ExternalBond atomName="OD1" />
       <ExternalBond atomName="C" />
     </Residue>
     <Residue name="CHYP" override="1">
@@ -66513,6 +66514,7 @@
       <Bond atomName1="C" atomName2="O" />
       <Bond atomName1="C" atomName2="OXT" />
       <ExternalBond atomName="N" />
+      <ExternalBond atomName="OD1" />
     </Residue>
     <Residue name="COLS" override="1">
       <Atom name="N" type="protein-N" charge="-0.3821" />
@@ -66673,6 +66675,7 @@
       <Bond atomName1="CA" atomName2="HA" />
       <Bond atomName1="CA" atomName2="C" />
       <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="OD1" />
       <ExternalBond atomName="C" />
     </Residue>
     <Residue name="NOLS" override="1">


### PR DESCRIPTION
This PR makes the following changes:
- Fix problems with the external bonds for the following residues: terminal residues (e.g. NNLN, CNLN), OLP, and  OME.
    - Terminal residue issue pointed out [here](https://github.com/openmm/openmm/issues/3191#issuecomment-953239669) 
- Update the initialization script according to OpenMM API updates introduced by https://github.com/openmm/openmm/pull/3303

Requires: https://github.com/ParmEd/ParmEd/pull/1206

A couple remaining issues:
1. @peastman pointed out that the HYP residues does not use PDB v3 atom names [here](https://github.com/openmm/openmm/issues/3191#issuecomment-953335317). The hydrogens.xml I generated relies on GLYCAM_06j-1.xml to determine the hydrogens for each residue. I'm not sure why the HYP hydrogen names do not match the ones in CHYP/NHYP. Could you share your script for converting the HYP hydrogen names to PDB v3 names? Or maybe you could just make the changes directly to the updated GLYCAM_06j-1.xml included in this PR and commit them?
2. @peastman : I've fixed the bond perception issues for residues that I saw problems for and then chose a couple more random residues and checked thata those looked right. I'm not sure if there are more bond perception problems though, would you be able to randomly choose some residues and see if the external bonds look right?
