### PR TITLE
Fix #210: gaff atom type name is now correctly passed

### DIFF
--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -733,8 +733,15 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
             if ('acdoctor' in subprocess.getoutput(cmd)):
                 supports_acdoctor = True
 
+            if (self._gaff_major_version == 1):
+                atom_type = 'gaff'
+            elif (self._gaff_major_version == 2):
+                atom_type = 'gaff2'
+            else:
+                raise ValueError(f'gaff major version {self._gaff_major_version} unknown')
+
             # Run antechamber without charging (which is done separately)
-            cmd = f'antechamber -i {local_input_filename} -fi {input_format} -o out.mol2 -fo mol2 -s {verbosity} -at {self._gaff_major_version}'
+            cmd = f'antechamber -i {local_input_filename} -fi {input_format} -o out.mol2 -fo mol2 -s {verbosity} -at {atom_type}'
             if supports_acdoctor:
                 cmd += ' -dr ' + ('yes' if verbosity else 'no')
 


### PR DESCRIPTION
This should fix #210 by passing the correct atom type name.

I'm not entirely clear whether the atom type arguments accepted changed at some point. If so, I should figure out what version of ambertools this changed in and alter the input accordingly.