### PR TITLE
Fix #216: Remove % sign from parmchk2 command

### DIFF
--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -766,7 +766,7 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
             _logger.debug(output)
 
             # Run parmchk.
-            cmd = f"parmchk2 -i out.mol2 -f mol2 -p {self.gaff_dat_filename} -o out.frcmod -s %{self._gaff_major_version}"
+            cmd = f"parmchk2 -i out.mol2 -f mol2 -p {self.gaff_dat_filename} -o out.frcmod -s {self._gaff_major_version}"
             _logger.debug(cmd)
             output = subprocess.getoutput(cmd)
             if not os.path.exists('out.frcmod'):


### PR DESCRIPTION
Unnecessary % sign in the parmchk2 command string sometimes gets filled
with junk characters on Windows and stops the command from running
successfully. This behaviour only occurs on some Windows systems and
does not occur on Linux or Mac.