### PR TITLE
Fix #214: Leave temp dir before raising exceptions

### DIFF
--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -762,6 +762,7 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
                 msg += read_file_contents(local_input_filename)
                 msg += 8 * "----------" + '\n'
                 # TODO: Run antechamber again with acdoctor mode on (-dr yes) to get more debug info, if supported
+                os.chdir(cwd)
                 raise Exception(msg)
             _logger.debug(output)
 
@@ -780,6 +781,7 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
                 msg += 8 * "----------" + '\n'
                 msg += read_file_contents('out.mol2')
                 msg += 8 * "----------" + '\n'
+                os.chdir(cwd)
                 raise Exception(msg)
             _logger.debug(output)
             self._check_for_errors(output)


### PR DESCRIPTION
Change out of temporary directory before raising an exception that
causes the directory to be deleted as the context manager exits. If not
done, a PermissionError is raised repeatedly on Windows and the
message from the original exception is very difficult to read. This
behaviour was observed for the parmchk2 command, but the fix has also
been applied to the antechamber command.

This fix could also have been implemented using try/finally - I can redo it with that if you prefer. 