### PR TITLE
Fix #215: Copy gaff dat file to temp dir

### DIFF
--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -766,7 +766,8 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
             _logger.debug(output)
 
             # Run parmchk.
-            cmd = f"parmchk2 -i out.mol2 -f mol2 -p {self.gaff_dat_filename} -o out.frcmod -s %{self._gaff_major_version}"
+            shutil.copy(self.gaff_dat_filename, os.getcwd())
+            cmd = f"parmchk2 -i out.mol2 -f mol2 -p {os.path.basename(self.gaff_dat_filename)} -o out.frcmod -s %{self._gaff_major_version}"
             _logger.debug(cmd)
             output = subprocess.getoutput(cmd)
             if not os.path.exists('out.frcmod'):

--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -766,8 +766,8 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
             _logger.debug(output)
 
             # Run parmchk.
-            shutil.copy(self.gaff_dat_filename, os.getcwd())
-            cmd = f"parmchk2 -i out.mol2 -f mol2 -p {os.path.basename(self.gaff_dat_filename)} -o out.frcmod -s %{self._gaff_major_version}"
+            shutil.copy(self.gaff_dat_filename, 'gaff.dat')
+            cmd = f"parmchk2 -i out.mol2 -f mol2 -p gaff.dat -o out.frcmod -s %{self._gaff_major_version}"
             _logger.debug(cmd)
             output = subprocess.getoutput(cmd)
             if not os.path.exists('out.frcmod'):


### PR DESCRIPTION
Copy the gaff dat file to the temporary directory before running
parmchk2 to avoid problems with spaces in the path.