### PR TITLE
Tweak CI: Switch to Micromamba, pin to supported OpenFF Toolkit versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         latest-openff-toolkit: [true, false]
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
@@ -18,49 +22,50 @@ jobs:
   test:
     name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}, Latest openff-toolkit ${{ matrix.latest-openff-toolkit }}
     runs-on: ${{ matrix.os }}
+    env:
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        python-version: [3.7, 3.8, 3.9]
-        latest-openff-toolkit: ["true", "false"]
+        python-version: ["3.7", "3.8", "3.9"]
+        latest-openff-toolkit: [true, false]
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Setup Conda Environment
-      uses: conda-incubator/setup-miniconda@v2
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml
-        mamba-version: "*"
-        channel-priority: true
-        channels: jaimergp/label/unsupported-cudatoolkit-shim,conda-forge,defaults
-        activate-environment: test
-        auto-update-conda: true
-        auto-activate-base: false
-        show-channel-urls: true
+        extra-specs: |
+          python=${{ matrix.python-version }}
+          mamba
+
+    - name: License OpenEye
+      run: |
+        echo "${SECRET_OE_LICENSE}" > ${OE_LICENSE}
+        python -c "from openeye import oechem; assert oechem.OEChemIsLicensed()"
+      env:
+        SECRET_OE_LICENSE: ${{ secrets.OE_LICENSE }}
 
     - name: "Install latest openff-toolkit"
-      if: ${{ matrix.latest-openff-toolkit }}
+      if: ${{ matrix.latest-openff-toolkit == true }}
       run: |
-        mamba update -y -c conda-forge/label/openff-toolkit_rc openff-toolkit
-
+        # Until #225 is complete, we should not assume compatibility with new API
+        mamba install "openff-toolkit =0.10.6" -c conda-forge -y
 
     - name: Install Package
-      shell: bash -l {0}
       run: |
         # Can't use 'develop' mode because we remove symlinks after install is complete
         python setup.py install
 
     - name: Conda Environment Information
-      shell: bash -l {0}
       run: |
         conda info
         conda list
 
     - name: Test Installed Package
-      shell: bash -l {0}
       run: |
         pytest -v -x -s --log-cli-level $LOGLEVEL --cov=openmmforcefields openmmforcefields/tests/test_amber_import.py
         pytest -v -x -s --log-cli-level $LOGLEVEL --cov=openmmforcefields openmmforcefields/tests/test_template_generators.py
@@ -70,13 +75,11 @@ jobs:
         KMP_DUPLICATE_LIB_OK: "True"
 
     - name: Test AMBER conversion
-      shell: bash -l {0}
       run: |
         python convert_amber.py --input gaff.yaml --log gaff-tests.csv --verbose
       working-directory: ./amber
 
     - name: Test CHARMM conversion
-      shell: bash -l {0}
       run: |
 
         # TODO: Uncomment these tests when new ParmEd is released

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,112 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# profraw files from LLVM? Unclear exactly what triggers this
+# There are reports this comes from LLVM profiling, but also Xcode 9.
+*profraw
+
+# In-tree generated files
+*/_version.py
+
+# OS X extra files
+*.DS_Store

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
   - dglteam # espaloma; TODO: Remove this once espaloma is fully on conda-forge
   - defaults
+  - openeye
 
 dependencies:
     # Base depends
@@ -26,9 +27,11 @@ dependencies:
 
     # JSON caching of residue templates
   - tinydb
+    # OpenEye toolkits are only used to speed up testing; they are not required for use
+  - openeye-toolkits
 
     # OpenFF toolkit and force fields
-  - openff-toolkit >=0.10.3|<=0.10.0
+  - openff-toolkit =0.10.6
   - openff-forcefields >=1.2.0
 
     # Validating URLs

--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -1254,7 +1254,14 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
             root, ext = os.path.splitext(filename)
             # Only add variants without '_unconstrained'
             if '_unconstrained' not in root:
-                file_names.append(root)
+                continue
+            # The OpenFF Toolkit ships two versions of its ff14SB port, one with SMIRNOFF-style
+            # impropers and one with Amber-style impropers. The latter requires a special handler
+            # (`AmberImproperTorsionHandler`) that is not shipped with the toolkit. See
+            # https://github.com/openforcefield/amber-ff-porting/tree/0.0.3
+            if root.startswith("ff14sb") and 'off_impropers' not in root:
+                continue
+            file_names.append(root)
 
         return file_names
 


### PR DESCRIPTION
This  might already be in a branch somewhere, but it should be easier to get through if it's a more atomic change. I noticed when working on something else that
* It takes CI ~10 minutes to set up a conda environment
* There is no `.gitignore` file in this repo