### PR TITLE
Turn off macos + Python 3.10 tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10"]
         latest-openff-toolkit: [true, false]
+        exclude:
+          - python-version: "3.10"
+            os: macos-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This is a small change to see if the testing infrastructure is back to being online. If it is, everything should be green and codecov should (should! .... should!) report some useful information.