### PR TITLE
Error if custom force is found

### DIFF
--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -1030,12 +1030,23 @@ class OpenMMSystemMixin:
                 element=element_symbol, mass=as_attrib(atom.mass))
             atom_type.set('class', atom.typename) # 'class' is a reserved Python keyword, so use alternative API
 
+        supported_forces = {
+            "NonbondedForce",
+            "HarmonicAngleForce",
+            "HarmonicBondForce",
+            "PeriodicTorsionForce",
+        }
+
         # Compile forces into a dict
         forces = dict()
         for force in system.getForces():
             force_name = force.__class__.__name__
+
             if force_name in forces:
-                raise Exception("Two instances of force {force_name} appear in System")
+                raise Exception(f"Two instances of force {force_name} appear in System")
+            if force_name not in supported_forces:
+                raise Exception(f"Custom forces not supported. Found force of type {force_name}.")
+
             forces[force_name] = force
 
         def classes(atom_indices):


### PR DESCRIPTION
This is a short-term band-aid for #247 - implementing them will take more than a trivial amount of time so we should at least error out instead of silently ignoring entire forces in user's systems.