### PR TITLE
Removing Openeye from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,6 @@ jobs:
   test:
     name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}, Latest openff-toolkit ${{ matrix.latest-openff-toolkit }}
     runs-on: ${{ matrix.os }}
-    env:
-      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
     strategy:
       fail-fast: false
       matrix:
@@ -43,14 +41,6 @@ jobs:
         environment-file: devtools/conda-envs/test_env.yaml
         create-args: >-
           python=${{ matrix.python-version }}
-
-    - name: License OpenEye
-      shell: bash -l {0}
-      run: |
-        echo "${SECRET_OE_LICENSE}" > ${OE_LICENSE}
-        python -c "from openeye import oechem; assert oechem.OEChemIsLicensed()"
-      env:
-        SECRET_OE_LICENSE: ${{ secrets.OE_LICENSE }}
 
     - name: "Install openff-toolkit >= 0.11 API changes"
       if: ${{ matrix.latest-openff-toolkit == true }}


### PR DESCRIPTION
We shouldn't be needing openeye in this project, CI tests are failing because of the License. These changes remove this.