### PR TITLE
Do not use old OpenFF Toolkit versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}, Latest openff-toolkit ${{ matrix.latest-openff-toolkit }}
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
@@ -29,7 +29,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10"]
-        latest-openff-toolkit: [true, false]
         exclude:
           - python-version: "3.10"
             os: macos-latest
@@ -51,16 +50,6 @@ jobs:
         python -c "from openeye import oechem; assert oechem.OEChemIsLicensed()"
       env:
         SECRET_OE_LICENSE: ${{ secrets.OE_LICENSE }}
-
-    - name: "Install openff-toolkit >= 0.11 API changes"
-      if: ${{ matrix.latest-openff-toolkit == true }}
-      run: |
-        micromamba update -y -c conda-forge "openff-toolkit >=0.11.3"
-
-    - name: "Install openff-toolkit <  0.11 API changes"
-      if: ${{ matrix.latest-openff-toolkit == false }}
-      run: |
-        micromamba install -y -c conda-forge "openff-toolkit==0.10.6" "openff-toolkit-base==0.10.6"
 
     - name: Install Package
       run: |
@@ -106,7 +95,6 @@ jobs:
       working-directory: ./charmm
 
     - name: Run docstrings
-      if: ${{ matrix.latest-openff-toolkit == true }}
       continue-on-error: True
       run: |
         pytest --doctest-modules openmmforcefields --ignore=openmmforcefields/tests

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -23,7 +23,7 @@ dependencies:
 
     # Requirements for conversion tools
   - pyyaml
-  - ambertools >=18.0 # contains sufficiently recent ParmEd
+  - ambertools =22
   - lxml
   - networkx
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,8 +19,7 @@ dependencies:
     # Requirements for converted force field installer
   - openmm >=7.6.0
 
-  - openff-units >=0.1.8
-  - openff-amber-ff-ports >=0.0.3
+  - openff-toolkit >=0.11
 
     # Requirements for conversion tools
   - pyyaml

--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -1283,6 +1283,8 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
            https://github.com/openforcefield/openff-toolkit/issues/477
 
         """
+        # It may be better to use an allow list instead of grabbing all and filtering things out.
+
         from openff.toolkit.typing.engines.smirnoff import get_available_force_fields
         file_names = list()
         for filename in get_available_force_fields(full_paths=False):
@@ -1290,12 +1292,20 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
             # Only add variants without '_unconstrained'
             if '_unconstrained' in root:
                 continue
+
+            # Don't load water models as small molecule force fields
+            if root.startswith("tip"):
+                continue
+            if root.startswith("opc"):
+                continue
+
             # The OpenFF Toolkit ships two versions of its ff14SB port, one with SMIRNOFF-style
             # impropers and one with Amber-style impropers. The latter requires a special handler
             # (`AmberImproperTorsionHandler`) that is not shipped with the toolkit. See
             # https://github.com/openforcefield/amber-ff-porting/tree/0.0.3
             if root.startswith("ff14sb") and 'off_impropers' not in root:
                 continue
+
             file_names.append(root)
 
         return file_names

--- a/openmmforcefields/tests/test_template_generators.py
+++ b/openmmforcefields/tests/test_template_generators.py
@@ -67,12 +67,7 @@ class TestGAFFTemplateGenerator(unittest.TestCase):
         molecule = Molecule.from_smiles('C=O')
         molecule.generate_conformers(n_conformers=1)
 
-        uses_old_api = hasattr(molecule.atoms[0], "element")
-
-        molecule.conformers[0][0,0] += ensure_quantity(
-            unit.Quantity(0.1, unit.angstroms),
-            "openmm" if uses_old_api else "openff",
-        )
+        molecule.conformers[0][0,0] += unit.Quantity(0.1, unit.angstroms)
 
         molecules.insert(0, molecule)
         # DEBUG END
@@ -244,7 +239,7 @@ class TestGAFFTemplateGenerator(unittest.TestCase):
 
     def test_charge_from_molecules(self):
         """Test that user-specified partial charges are used if requested"""
-        from openff.units.openmm import ensure_quantity
+        from openff.units import unit
 
         # Create a generator that does not know about any molecules
         generator = self.TEMPLATE_GENERATOR()
@@ -256,12 +251,6 @@ class TestGAFFTemplateGenerator(unittest.TestCase):
         # Check that parameterizing a molecule using user-provided charges produces expected charges
 
         molecule = self.molecules[0]
-        uses_old_api = hasattr(molecule.atoms[0], "element")
-
-        if uses_old_api:
-            from openmm import unit
-        else:
-            from openff.units import unit
 
         # Populate the molecule with arbitrary partial charges that still sum to 0.0
         molecule.partial_charges = unit.Quantity(
@@ -269,9 +258,9 @@ class TestGAFFTemplateGenerator(unittest.TestCase):
             unit.elementary_charge,
         )
 
-        assert (molecule.partial_charges is not None)
+        assert molecule.partial_charges is not None
 
-        assert not np.all(ensure_quantity(molecule.partial_charges, "openff").m == 0)
+        assert not np.all(molecule.partial_charges.m == 0)
 
         generator.add_molecules(molecule)
 
@@ -730,8 +719,6 @@ class TestSMIRNOFFTemplateGenerator(TestGAFFTemplateGenerator):
         from openff.units.openmm import ensure_quantity
         from openmm import unit
 
-        uses_old_api = hasattr(molecule.atoms[0], "element")
-
         temperature = 300 * unit.kelvin
         collision_rate = 1.0 / unit.picoseconds
         timestep = 1.0 * unit.femtoseconds
@@ -747,7 +734,7 @@ class TestSMIRNOFFTemplateGenerator(TestGAFFTemplateGenerator):
 
         new_molecule.conformers[0] = ensure_quantity(
             new_positions,
-            "openmm" if uses_old_api else "openff",
+            "openff",
         )
 
 
@@ -861,8 +848,6 @@ class TestEspalomaTemplateGenerator(TestGAFFTemplateGenerator):
         from openff.units.openmm import ensure_quantity
         from openmm import unit
 
-        uses_old_api = hasattr(molecule.atoms[0], "element")
-
         temperature = 300 * unit.kelvin
         collision_rate = 1.0 / unit.picoseconds
         timestep = 1.0 * unit.femtoseconds
@@ -878,7 +863,7 @@ class TestEspalomaTemplateGenerator(TestGAFFTemplateGenerator):
 
         new_molecule.conformers[0] = ensure_quantity(
             new_positions,
-            "openmm" if uses_old_api else "openff",
+            "openff",
         )
 
         # Clean up


### PR DESCRIPTION
`openff-toolkit <0.11` will no longer be supported soon; this drops the support and checks.