### PR TITLE
Allow parsing of offxml strings

### DIFF
--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -1301,7 +1301,7 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
                 self._smirnoff_forcefield = openff.toolkit.typing.engines.smirnoff.ForceField(forcefield)
             except Exception as e:
                 _logger.error(e)
-                raise ValueError(f"Can't find specified SMIRNOFF force field ({forcefield}) in install paths") from e
+                raise ValueError(f"Can't find specified SMIRNOFF force field ({forcefield}) in install paths or parse the input as a string.") from e
 
         # Delete constraints, if present
         if 'Constraints' in self._smirnoff_forcefield._parameter_handlers:

--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -1275,14 +1275,19 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
 
         # Create ForceField object
         import openff.toolkit.typing.engines.smirnoff
-        try:
-            filename = forcefield
-            if not filename.endswith('.offxml'):
-                filename += '.offxml'
+
+        # check for an installed force field
+        available_force_fields = openff.toolkit.typing.engines.smirnoff.get_available_force_fields()
+        if (filename := forcefield + ".offxml") in available_force_fields or (filename := forcefield) in available_force_fields:
             self._smirnoff_forcefield = openff.toolkit.typing.engines.smirnoff.ForceField(filename)
-        except Exception as e:
-            _logger.error(e)
-            raise ValueError(f"Can't find specified SMIRNOFF force field ({forcefield}) in install paths")
+
+        # just try parsing the input and let openff handle the error
+        else:
+            try:
+                self._smirnoff_forcefield = openff.toolkit.typing.engines.smirnoff.ForceField(forcefield)
+            except Exception as e:
+                _logger.error(e)
+                raise ValueError(f"Can't find specified SMIRNOFF force field ({forcefield}) in install paths or parse the input")
 
         # Delete constraints, if present
         if 'Constraints' in self._smirnoff_forcefield._parameter_handlers:

--- a/openmmforcefields/tests/test_template_generators.py
+++ b/openmmforcefields/tests/test_template_generators.py
@@ -1,12 +1,15 @@
 import copy
 import logging
 import os
+import pytest
 import tempfile
 import unittest
 
 import numpy as np
 import openmm
 from openff.toolkit.topology import Molecule
+from openff.toolkit.typing.engines.smirnoff import ForceField as OFFForceField
+from openff.units import unit as OFFUnit
 from openmm.app import PME, ForceField, Modeller, NoCutoff, PDBFile
 
 from openmmforcefields.generators import (
@@ -836,6 +839,40 @@ class TestSMIRNOFFTemplateGenerator(TestGAFFTemplateGenerator):
             assert generator.forcefield == forcefield
             assert generator.smirnoff_filename.endswith(forcefield + '.offxml')
             assert os.path.exists(generator.smirnoff_filename)
+
+    def test_bespoke_force_field(self):
+        """
+        Make sure a molecule can be parameterised using a bespoke force field passed as a string to
+        the template generator.
+        """
+
+        custom_sage = OFFForceField("openff-2.0.0.offxml")
+        # Create a simple molecule with one bond type
+        ethane = Molecule.from_smiles("C")
+        # Label ethane to get the bond type (not hard coded incase this changes in future)
+        bond_parameter = custom_sage.label_molecules(ethane.to_topology())[0]["Bonds"][(0, 1)]
+        # Edit the bond parameter
+        bonds = custom_sage.get_parameter_handler("Bonds")
+        new_parameter = bonds[bond_parameter.smirks]
+        new_parameter.length = 2 * OFFUnit.angstrom
+
+        # Use the custom sage passed as string to build a template and an openmm system
+        generator = SMIRNOFFTemplateGenerator(molecules=ethane, forcefield=custom_sage.to_string())
+
+        # Create a ForceField
+        openmm_forcefield = openmm.app.ForceField()
+        # Register the template generator
+        openmm_forcefield.registerTemplateGenerator(generator.generator)
+        # Use OpenMM app to generate the system
+        openmm_system = openmm_forcefield.createSystem(ethane.to_topology().to_openmm(), removeCMMotion=False,
+                                                       nonbondedMethod=NoCutoff)
+
+        # Check the bond length has been updated
+        forces = {force.__class__.__name__: force for force in openmm_system.getForces()}
+        bond_force = forces["HarmonicBondForce"]
+        for i in range(bond_force.getNumBonds()):
+            _, _, length, _ = bond_force.getBondParameters(i)
+            assert pytest.approx(length.value_in_unit(openmm.unit.angstrom)) == 2
 
 
 class TestEspalomaTemplateGenerator(TestGAFFTemplateGenerator):


### PR DESCRIPTION
This PR allows an offxml string to be used as a small molecule force field for the `SystemGenerator` and `SMIRNOFFTemplateGenerator` see the example which now works with this PR.

```python
"Try and load a OFFXML string into a system generator object"
from openmmforcefields.generators import SystemGenerator
from openff.toolkit.typing.engines.smirnoff import ForceField
from openff.toolkit.topology import Molecule
import openmm

# load the ff
ff = ForceField("openff-2.0.0.offxml")
# create a system generator
system_gen = SystemGenerator(
    forcefields=['amber/ff14SB.xml', 'amber/tip3p_standard.xml'],
    small_molecule_forcefield=ff.to_string()
)
mol = Molecule.from_smiles("CC")
system = system_gen.create_system(topology=mol.to_topology().to_openmm(), molecules=mol)
with open("system.xml", "w") as output:
    output.write(openmm.XmlSerializer.serialize(system))
```