### PR TITLE
[DNM] Pinning ambertools version to <= 22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         latest-openff-toolkit: [true, false]
         exclude:
           - python-version: "3.10"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
         latest-openff-toolkit: [true, false]
         exclude:
           - python-version: "3.10"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10"]
         latest-openff-toolkit: [true, false]
         exclude:
           - python-version: "3.10"

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -24,7 +24,7 @@ dependencies:
 
     # Requirements for conversion tools
   - pyyaml
-  - ambertools >=18.0 # contains sufficiently recent ParmEd
+  - ambertools <=22.0 # contains sufficiently recent ParmEd
   - lxml
   - networkx
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -41,6 +41,6 @@ dependencies:
     # TODO: Rework this once espaloma is on conda-forge
     #
   - pytorch >=1.8.0
-  - dgl
+  - dgl <1.1
   - qcportal >=0.15.0
   - espaloma

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -24,7 +24,7 @@ dependencies:
 
     # Requirements for conversion tools
   - pyyaml
-  - ambertools <=22.0 # contains sufficiently recent ParmEd
+  - ambertools =22.0
   - lxml
   - networkx
 

--- a/openmmforcefields/tests/test_template_generators.py
+++ b/openmmforcefields/tests/test_template_generators.py
@@ -784,6 +784,10 @@ class TestSMIRNOFFTemplateGenerator(TestGAFFTemplateGenerator):
         for small_molecule_forcefield in SMIRNOFFTemplateGenerator.INSTALLED_FORCEFIELDS:
             if "ff14sb" in small_molecule_forcefield:
                 continue
+            if "tip" in small_molecule_forcefield:
+                continue
+            if "opc" in small_molecule_forcefield:
+                continue
             print(f'Testing energies for {small_molecule_forcefield}...')
             # Create a generator that knows about a few molecules
             # TODO: Should the generator also load the appropriate force field files into the ForceField object?
@@ -820,6 +824,10 @@ class TestSMIRNOFFTemplateGenerator(TestGAFFTemplateGenerator):
         # Test all supported SMIRNOFF force fields
         for small_molecule_forcefield in SMIRNOFFTemplateGenerator.INSTALLED_FORCEFIELDS:
             if "ff14sb" in small_molecule_forcefield:
+                continue
+            if "tip" in small_molecule_forcefield:
+                continue
+            if "opc" in small_molecule_forcefield:
                 continue
             print(f'Testing energies for {small_molecule_forcefield}...')
             # Create a generator that knows about a few molecules

--- a/openmmforcefields/tests/test_template_generators.py
+++ b/openmmforcefields/tests/test_template_generators.py
@@ -534,6 +534,10 @@ class TestGAFFTemplateGenerator(unittest.TestCase):
         for small_molecule_forcefield in self.TEMPLATE_GENERATOR.INSTALLED_FORCEFIELDS:
             if "ff14sb" in small_molecule_forcefield:
                 continue
+            if "tip" in small_molecule_forcefield:
+                continue
+            if "opc" in small_molecule_forcefield:
+                continue
             print(f'Testing {small_molecule_forcefield}')
             # Create a generator that knows about a few molecules
             # TODO: Should the generator also load the appropriate force field files into the ForceField object?


### PR DESCRIPTION
Ambertools 23 changed the behavior and it is causing failures with our tests. This pins the version for now so we can get a release while we find a solution for #280 

Resolves #286 