### PR TITLE
Update SMIRNOFF/OpenFF docs/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ The atom ordering need not be the same.
 ### Examples using `GAFFTemplateGenerator` to generate small molecule GAFF parameters
 
 Create a GAFF template generator for a single molecule (benzene, created from SMILES) and register it with ForceField:
+
 ```python
 # Create an OpenFF Molecule object for benzene from SMILES
-from openff.toolkit.topology import Molecule
+from openff.toolkit import Molecule
 molecule = Molecule.from_smiles('c1ccccc1')
 # Create the GAFF template generator
 from openmmforcefields.generators import GAFFTemplateGenerator
@@ -123,13 +124,17 @@ from openmm.app import PDBFile
 pdbfile = PDBFile('t4-lysozyme-L99A-with-benzene.pdb')
 system = forcefield.createSystem(pdbfile.topology)
 ```
+
 The latest available GAFF version is used if none is specified.
 You can check which GAFF version is in use with
+
 ```python
->>> generator.gaff_version
+>>> gaff.gaff_version
 '2.11'
 ````
+
 Create a template generator for a specific GAFF version for multiple molecules read from an SDF file:
+
 ```python
 molecules = Molecule.from_file('molecules.sdf')
 gaff = GAFFTemplateGenerator(molecules=molecules, forcefield='gaff-2.11')
@@ -146,25 +151,26 @@ To check which GAFF versions are supported, examine the `INSTALLED_FORCEFIELDS` 
 ```
 You can optionally specify a file that contains a cache of pre-parameterized molecules:
 ```python
-generator = GAFFTemplateGenerator(cache='gaff-molecules.json', forcefield='gaff-1.80')
+generator = GAFFTemplateGenerator(cache='gaff-molecules.json', forcefield='gaff-1.8')
 ```
 Newly parameterized molecules will be written to the cache, saving time next time these molecules are encountered.
 
 ## Using the Open Force Field Initiative SMIRNOFF small molecule force fields
 
-The `openmmforcefields` package includes a [residue template generator](http://docs.openmm.org/latest/userguide/application.html#adding-residue-template-generators) for [the OpenMM `ForceField` class](http://docs.openmm.org/latest/api-python/generated/openmm.app.forcefield.ForceField.html#openmm.app.forcefield.ForceField) that automatically generates OpenMM residue templates for small molecules lacking parameters using the [Open Force Field Initiative](http://openforcefield.org) [SMIRNOFF](https://open-forcefield-toolkit.readthedocs.io/en/0.6.0/smirnoff.html) small molecule force fields.
-This includes the [`openff-1.0.0` ("Parsley")](https://openforcefield.org/news/introducing-openforcefield-1.0/) small molecule force field, as well as [newer versions of this force field](https://github.com/openforcefield/openff-forcefields).
+The `openmmforcefields` package includes a [residue template generator](http://docs.openmm.org/latest/userguide/application.html#adding-residue-template-generators) for [the OpenMM `ForceField` class](http://docs.openmm.org/latest/api-python/generated/openmm.app.forcefield.ForceField.html#openmm.app.forcefield.ForceField) that automatically generates OpenMM residue templates for small molecules lacking parameters using the [Open Force Field Initiative](http://openforcefield.org) [SMIRNOFF](https://openforcefield.github.io/standards/standards/smirnoff/)small molecule force fields.
+This includes the [`openff-1.x.y` ("Parsley")](https://openforcefield.org/news/introducing-openforcefield-1.0/) and [`openff-2.x.y` ("Sage")](https://pubs.acs.org/doi/10.1021/acs.jctc.3c00039) small molecule force field lines, including the [most recent force field in each lines](https://github.com/openforcefield/openff-forcefields).
 
 The `SMIRNOFFTemplateGenerator` residue template generator operates in a manner very similar to `GAFFTemplateGenerator`, so we only highlight its differences here.
 
 ### Examples using `SMIRNOFFTemplateGenerator` to generate small molecule SMIRNOFF parameters
 
 Create a SMIRNOFF template generator for a single molecule (benzene, created from SMILES) and register it with ForceField:
+
 ```python
 # Create an OpenFF Molecule object for benzene from SMILES
-from openff.toolkit.topology import Molecule
+from openff.toolkit import Molecule
 molecule = Molecule.from_smiles('c1ccccc1')
-# Create the SMIRNOFF template generator with the default installed force field (openff-1.0.0)
+# Create the SMIRNOFF template generator with the default installed force field (openff-2.1.0)
 from openmmforcefields.generators import SMIRNOFFTemplateGenerator
 smirnoff = SMIRNOFFTemplateGenerator(molecules=molecule)
 # Create an OpenMM ForceField object with AMBER ff14SB and TIP3P with compatible ions
@@ -173,13 +179,17 @@ forcefield = ForceField('amber/protein.ff14SB.xml', 'amber/tip3p_standard.xml', 
 # Register the SMIRNOFF template generator
 forcefield.registerTemplateGenerator(smirnoff.generator)
 ```
+
 The latest official Open Force Field Initiative release ([`openff-1.2.0`](https://github.com/openforcefield/openff-forcefields) of the ["Parsley" small molecule force field](https://openforcefield.org/news/introducing-openforcefield-1.0/)) is used if none is specified.
 You can check which SMIRNOFF force field is in use with
+
 ```python
 >>> smirnoff.smirnoff_filename
-'/Users/choderaj/Library/Caches/Python-Eggs/openforcefields-1.0.0-py3.7.egg-tmp/openforcefields/offxml/openff-1.0.0.offxml'
+'/Users/mattthompson/mambaforge/envs/openmmforcefields/lib/python3.11/site-packages/openforcefields/offxml/openff-2.1.0.offxml'
 ```
+
 Create a template generator for a specific SMIRNOFF force field for multiple molecules read from an SDF file:
+
 ```python
 molecules = Molecule.from_file('molecules.sdf')
 # Create a SMIRNOFF residue template generator from the official openff-1.0.0 release,
@@ -191,22 +201,28 @@ smirnoff = SMIRNOFFTemplateGenerator(molecules=molecules, forcefield='smirnoff99
 # Use a local .offxml file instead
 smirnoff = SMIRNOFFTemplateGenerator(molecules=molecules, forcefield='local-file.offxml')
 ```
+
 You can also add molecules to the generator later, even after the generator has been registered:
+
 ```python
 smirnoff.add_molecules(molecule)
 smirnoff.add_molecules([molecule1, molecule2])
 ```
+
 To check which SMIRNOFF force fields are automatically installed, examine the `INSTALLED_FORCEFIELDS` attribute:
+
 ```python
 >>> print(SMIRNOFFTemplateGenerator.INSTALLED_FORCEFIELDS)
-['openff-1.0.1', 'openff-1.1.1', 'openff-1.0.0-RC1', 'openff-1.2.0', 'openff-1.1.0', 'openff-1.0.0', 'openff-1.0.0-RC2', 'smirnoff99Frosst-1.0.2', 'smirnoff99Frosst-1.0.0', 'smirnoff99Frosst-1.1.0', 'smirnoff99Frosst-1.0.4', 'smirnoff99Frosst-1.0.8', 'smirnoff99Frosst-1.0.6', 'smirnoff99Frosst-1.0.3', 'smirnoff99Frosst-1.0.1', 'smirnoff99Frosst-1.0.5', 'smirnoff99Frosst-1.0.9', 'smirnoff99Frosst-1.0.7']
+['smirnoff99Frosst-1.0.2', 'smirnoff99Frosst-1.0.0', 'smirnoff99Frosst-1.1.0', 'smirnoff99Frosst-1.0.4', 'smirnoff99Frosst-1.0.8', 'smirnoff99Frosst-1.0.6', 'smirnoff99Frosst-1.0.3', 'smirnoff99Frosst-1.0.1', 'smirnoff99Frosst-1.0.5', 'smirnoff99Frosst-1.0.9', 'smirnoff99Frosst-1.0.7', 'ff14sb_off_impropers_0.0.2', 'ff14sb_off_impropers_0.0.1', 'ff14sb_off_impropers_0.0.3', 'tip3p_fb-1.1.0', 'tip3p_fb-1.0.0', 'openff-1.0.1', 'openff-1.1.1', 'openff-1.0.0-RC1', 'opc3', 'opc3-1.0.0', 'openff-2.1.0-rc.1', 'openff-1.2.0', 'openff-1.3.0', 'tip3p-1.0.0', 'opc-1.0.2', 'openff-2.0.0-rc.2', 'opc-1.0.0', 'openff-2.1.0', 'openff-2.0.0', 'tip4p_fb-1.0.1', 'tip3p', 'opc3-1.0.1', 'opc', 'tip3p_fb-1.1.1', 'openff-1.1.0', 'openff-1.0.0', 'openff-1.0.0-RC2', 'tip3p-1.0.1', 'openff-1.3.1', 'openff-1.2.1', 'openff-1.3.1-alpha.1', 'tip4p_fb', 'tip3p_fb', 'tip4p_fb-1.0.0', 'openff-2.0.0-rc.1', 'opc-1.0.1']
 ```
+
 You can optionally specify a file that contains a cache of pre-parameterized molecules:
+
 ```python
 smirnoff = SMIRNOFFTemplateGenerator(cache='smirnoff-molecules.json', forcefield='openff-1.2.0')
 ```
-Newly parameterized molecules will be written to the cache, saving time next time these molecules are encountered.
 
+Newly parameterized molecules will be written to the cache, saving time next time these molecules are encountered.
 
 ## Using espaloma to generate small molecule force fields
 
@@ -222,7 +238,7 @@ The `EspalomaTemplateGenerator` residue template generator operates in a manner 
 Create an espaloma template generator for a single molecule (benzene, created from SMILES) and register it with ForceField:
 ```python
 # Create an OpenFF Molecule object for benzene from SMILES
-from openff.toolkit.topology import Molecule
+from openff.toolkit import Molecule
 molecule = Molecule.from_smiles('c1ccccc1')
 # Create the SMIRNOFF template generator with the released espaloma-0.2.0 force field
 from openmmforcefields.generators import EspalomaTemplateGenerator

--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -46,7 +46,7 @@ class SmallMoleculeTemplateGenerator:
 
         Parameters
         ----------
-        molecules : openff.toolkit.topology.Molecule or list, optional, default=None
+        molecules : openff.toolkit.Molecule or list, optional, default=None
             Can alternatively be an object (such as an OpenEye OEMol or RDKit Mol or SMILES string) that can be used to construct a Molecule.
             Can also be a list of Molecule objects or objects that can be used to construct a Molecule.
             If specified, these molecules will be recognized and parameterized as needed.
@@ -93,7 +93,7 @@ class SmallMoleculeTemplateGenerator:
 
         Parameters
         ----------
-        molecules : openff.toolkit.topology.Molecule or list of Molecules, optional, default=None
+        molecules : openff.toolkit.Molecule or list of Molecules, optional, default=None
             Can alternatively be an object (such as an OpenEye OEMol or RDKit Mol or SMILES string) that can be used to construct a Molecule.
             Can also be a list of Molecule objects or objects that can be used to construct a Molecule.
             If specified, these molecules will be recognized and parameterized with antechamber as needed.
@@ -104,7 +104,7 @@ class SmallMoleculeTemplateGenerator:
 
         Add some Molecules later on after the generator has been registered:
 
-        >>> from openff.toolkit.topology import Molecule
+        >>> from openff.toolkit import Molecule
         >>> smiles = ('c1ccccc1', 'O=Cc1ccc(O)c(OC)c1', 'CN1CCC[C@H]1c2cccnc2')
         >>> mol1, mol2, mol3 = [Molecule.from_smiles(s, allow_undefined_stereo=True) for s in smiles]
         >>> generator.add_molecules(mol1)  # doctest: +SKIP
@@ -139,7 +139,7 @@ class SmallMoleculeTemplateGenerator:
         ----------
         residue : openmm.app.topology.Residue
             The residue to check
-        molecule_template : openff.toolkit.topology.Molecule
+        molecule_template : openff.toolkit.Molecule
             The Molecule template to compare it to
 
         Returns
@@ -209,7 +209,7 @@ class SmallMoleculeTemplateGenerator:
 
         Parameters
         ----------
-        molecule : openff.toolkit.topology.Molecule
+        molecule : openff.toolkit.Molecule
             The Molecule object to check for user charges
 
         Returns
@@ -243,7 +243,7 @@ class SmallMoleculeTemplateGenerator:
 
         Parameters
         ----------
-        molecule : openff.toolkit.topology.Molecule
+        molecule : openff.toolkit.Molecule
             The molecule whose atom names are to be modified in-place
         """
         from collections import defaultdict
@@ -294,7 +294,7 @@ class SmallMoleculeTemplateGenerator:
                         continue
 
                     # See if the template matches
-                    from openff.toolkit.topology import Molecule
+                    from openff.toolkit import Molecule
                     molecule_template = Molecule.from_smiles(entry['smiles'], allow_undefined_stereo=True)
                     _logger.debug(f"Checking against {entry['smiles']}")
                     if self._match_residue(residue, molecule_template):
@@ -364,7 +364,7 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
     Create a template generator for GAFF for a single Molecule and register it with ForceField:
 
     >>> # Define a Molecule using the OpenFF Molecule object
-    >>> from openff.toolkit.topology import Molecule
+    >>> from openff.toolkit import Molecule
     >>> molecule = Molecule.from_smiles('c1ccccc1')
     >>> # Create the GAFF template generator
     >>> from openmmforcefields.generators import GAFFTemplateGenerator
@@ -409,7 +409,7 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
 
         Parameters
         ----------
-        molecules : openff.toolkit.topology.Molecule or list, optional, default=None
+        molecules : openff.toolkit.Molecule or list, optional, default=None
             Can alternatively be an object (such as an OpenEye OEMol or RDKit Mol or SMILES string) that can be used to construct a Molecule.
             Can also be a list of Molecule objects or objects that can be used to construct a Molecule.
             If specified, these molecules will be recognized and parameterized with antechamber as needed.
@@ -426,7 +426,7 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
 
         Create a GAFF template generator for a single molecule (benzene, created from SMILES) and register it with ForceField:
 
-        >>> from openff.toolkit.topology import Molecule
+        >>> from openff.toolkit import Molecule
         >>> molecule = Molecule.from_smiles('c1ccccc1')
         >>> from openmmforcefields.generators import GAFFTemplateGenerator
         >>> gaff = GAFFTemplateGenerator(molecules=molecule)
@@ -559,7 +559,7 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
 
         Parameters
         ----------
-        molecules : openff.toolkit.topology.Molecule or list of Molecules, optional, default=None
+        molecules : openff.toolkit.Molecule or list of Molecules, optional, default=None
             Can alternatively be an object (such as an OpenEye OEMol or RDKit Mol or SMILES string) that can be used to construct a Molecule.
             Can also be a list of Molecule objects or objects that can be used to construct a Molecule.
             If specified, these molecules will be recognized and parameterized with antechamber as needed.
@@ -960,7 +960,7 @@ class OpenMMSystemMixin:
 
         Parameters
         ----------
-        molecule : openff.toolkit.topology.Molecule
+        molecule : openff.toolkit.Molecule
             The Molecule object
 
         Returns
@@ -980,7 +980,7 @@ class OpenMMSystemMixin:
 
         Parameters
         ----------
-        molecule : openff.toolkit.topology.Molecule
+        molecule : openff.toolkit.Molecule
             The Molecule to be converted
         system : openmm.System
             The System corresponding to molecule
@@ -1172,7 +1172,7 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
     small molecule force field and register it with ForceField:
 
     >>> # Define a Molecule using the OpenFF Molecule object
-    >>> from openff.toolkit.topology import Molecule
+    >>> from openff.toolkit import Molecule
     >>> molecule = Molecule.from_smiles('c1ccccc1')
     >>> # Create the SMIRNOFF template generator
     >>> from openmmforcefields.generators import SMIRNOFFTemplateGenerator
@@ -1215,7 +1215,7 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
 
         Parameters
         ----------
-        molecules : openff.toolkit.topology.Molecule or list, optional, default=None
+        molecules : openff.toolkit .Molecule or list, optional, default=None
             Can alternatively be an object (such as an OpenEye OEMol or RDKit Mol or SMILES string) that can be used to construct a Molecule.
             Can also be a list of Molecule objects or objects that can be used to construct a Molecule.
             If specified, these molecules will be recognized and parameterized with SMIRNOFF as needed.
@@ -1231,7 +1231,7 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
 
         Create a SMIRNOFF template generator for a single molecule (benzene, created from SMILES) and register it with ForceField:
 
-        >>> from openff.toolkit.topology import Molecule
+        >>> from openff.toolkit import Molecule
         >>> molecule = Molecule.from_smiles('c1ccccc1')
         >>> from openmmforcefields.generators import SMIRNOFFTemplateGenerator
         >>> smirnoff = SMIRNOFFTemplateGenerator(molecules=molecule)
@@ -1242,18 +1242,18 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
         The latest Open Force Field Initiative release is used if none is specified.
 
         >>> smirnoff.forcefield
-        'openff-2.0.0'
+        'openff-2.1.0'
 
         You can check which SMIRNOFF force field filename is in use with
 
         >>> smirnoff.smirnoff_filename  # doctest:+ELLIPSIS
-        '/.../openff-2.0.0.offxml'
+        '/.../openff-2.1.0.offxml'
 
         Create a template generator for a specific SMIRNOFF force field for multiple
         molecules read from an SDF file:
 
         >>> molecules = Molecule.from_file('molecules.sdf')  # doctest: +SKIP
-        >>> smirnoff = SMIRNOFFTemplateGenerator(molecules=molecules, forcefield='openff-2.0.0')  # doctest: +SKIP
+        >>> smirnoff = SMIRNOFFTemplateGenerator(molecules=molecules, forcefield='openff-2.1.0')  # doctest: +SKIP
 
         You can also add molecules later on after the generator has been registered:
 
@@ -1266,7 +1266,7 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
 
         You can optionally create or use a cache of pre-parameterized molecules:
 
-        >>> smirnoff = SMIRNOFFTemplateGenerator(cache='smirnoff.json', forcefield='openff-2.0.0')  # doctest: +SKIP
+        >>> smirnoff = SMIRNOFFTemplateGenerator(cache='smirnoff.json', forcefield='openff-2.1.0')  # doctest: +SKIP
 
         Newly parameterized molecules will be written to the cache, saving time next time!
         """
@@ -1275,7 +1275,7 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
 
         if forcefield is None:
             # Use latest supported Open Force Field Initiative release if none is specified
-            forcefield = 'openff-2.0.0'
+            forcefield = 'openff-2.1.0'
             # TODO: After toolkit provides date-ranked force fields,
             # use latest dated version if we can sort by date, such as self.INSTALLED_FORCEFIELDS[-1]
         self._forcefield = forcefield
@@ -1398,7 +1398,7 @@ class SMIRNOFFTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
 
         Parameters
         ----------
-        molecules : openff.toolkit.topology.Molecule or list of Molecules, optional, default=None
+        molecules : openff.toolkit.Molecule or list of Molecules, optional, default=None
             Can alternatively be an object (such as an OpenEye OEMol or RDKit Mol or SMILES string) that can be used to construct a Molecule.
             Can also be a list of Molecule objects or objects that can be used to construct a Molecule.
             If specified, these molecules will be recognized and parameterized with SMIRNOFF as needed.
@@ -1465,7 +1465,7 @@ class EspalomaTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
     small molecule force field and register it with ForceField:
 
     >>> # Define a Molecule using the OpenFF Molecule object
-    >>> from openff.toolkit.topology import Molecule
+    >>> from openff.toolkit import Molecule
     >>> molecule = Molecule.from_smiles('c1ccccc1')
     >>> # Create the Espaloma template generator
     >>> from openmmforcefields.generators import EspalomaTemplateGenerator
@@ -1511,7 +1511,7 @@ class EspalomaTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
 
         Parameters
         ----------
-        molecules : openff.toolkit.topology.Molecule or list, optional, default=None
+        molecules : openff.toolkit.Molecule or list, optional, default=None
             Can alternatively be an object (such as an OpenEye OEMol or RDKit Mol or SMILES string) that can be used to construct a Molecule.
             Can also be a list of Molecule objects or objects that can be used to construct a Molecule.
             If specified, these molecules will be recognized and parameterized with espaloma as needed.
@@ -1533,14 +1533,14 @@ class EspalomaTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
             
             Default behavior is to use ``openff_unconstrained-2.0.0`` for ``reference_forcefield`` and  `nn` for `charge_method`.
             User defined charges can be assigned by setting the ``charge_method`` to ``from_molecule`` 
-            if charges are assigned to openff.toolkit.topology.Molecule.
+            if charges are assigned to openff.toolkit.Molecule.
 
         Examples
         --------
 
         Create an Espaloma template generator for a single molecule (benzene, created from SMILES) and register it with ForceField:
 
-        >>> from openff.toolkit.topology import Molecule
+        >>> from openff.toolkit import Molecule
         >>> molecule = Molecule.from_smiles('c1ccccc1')
         >>> from openmmforcefields.generators import EspalomaTemplateGenerator
         >>> espaloma_generator = EspalomaTemplateGenerator(molecules=molecule)
@@ -1603,6 +1603,7 @@ class EspalomaTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
             self._reference_forcefield = template_generator_kwargs.get('reference_forcefield', 'openff_unconstrained-2.0.0')
             self._charge_method = template_generator_kwargs.get('charge_method', 'nn')
         else:
+            # Consider upgrading to 2.1.0, the recommended small moleucle force field for general use
             self._reference_forcefield = 'openff_unconstrained-2.0.0'
             self._charge_method = 'from-molecule'
 
@@ -1714,7 +1715,7 @@ class EspalomaTemplateGenerator(SmallMoleculeTemplateGenerator,OpenMMSystemMixin
 
         Parameters
         ----------
-        molecules : openff.toolkit.topology.Molecule or list of Molecules, optional, default=None
+        molecules : openff.toolkit.Molecule or list of Molecules, optional, default=None
             Can alternatively be an object (such as an OpenEye OEMol or RDKit Mol or SMILES string) that can be used to construct a Molecule.
             Can also be a list of Molecule objects or objects that can be used to construct a Molecule.
             If specified, these molecules will be recognized and parameterized with espaloma as needed.


### PR DESCRIPTION
I noticed that the README currently recommends an old (2020?) Parsley force field. I updated the default behavior of `SMIRNOFFTemplateGenerator` to use 2.1.0, our current recommended force field for general use. That should be the only behavior change introduced here.

I also took a dive through the examples in the README and many of the examples in the source code and updated them and/or made sure they ran. I don't think there are substantive or wacky changes there.