### PR TITLE
Do not generate conformers that will not be used

### DIFF
--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -608,9 +608,6 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
             _logger.debug(f'Using user-provided charges because partial charges are nonzero...')
         else:
             _logger.debug(f'Computing AM1-BCC charges...')
-            # NOTE: generate_conformers seems to be required for some molecules
-            # https://github.com/openforcefield/openff-toolkit/issues/492
-            molecule.generate_conformers(n_conformers=10)
             molecule.assign_partial_charges(partial_charge_method='am1bcc')
 
         # Geneate a single conformation


### PR DESCRIPTION
This line appears to be here for historical reasons, reasons which were made obsolete some time ago.

As a result of the [linked issue](https://github.com/openforcefield/openff-toolkit/issues/492) some three-plus years ago, `Molecule.assign_partial_charges` **does not** use the conformers in its `.conformers` attribute and instead generates them on-the-fly during the method call. Slicing out portions of the docstring:

```
Signature:
Molecule.assign_partial_charges(
    self,
    partial_charge_method: str,
    strict_n_conformers: bool = False,
    use_conformers: Optional[Iterable[pint.util.Quantity]] = None,
    toolkit_registry: Union[openff.toolkit.utils.toolkit_registry.ToolkitRegistry, openff.toolkit.utils.base_wrapper.ToolkitWrapper] = <ToolkitRegistry containing OpenEye Toolkit, The RDKit, AmberTools, Built-in Toolkit>,
    normalize_partial_charges: bool = True,
)
        Calculate partial atomic charges and store them in the molecule.

        By default, the conformers on the input molecule are not used
        in the charge calculation. Instead, any conformers needed for
        the charge calculation are generated by this method. If this
        behavior is undesired, specific conformers can be provided via the
        ``use_conformers`` argument.

        Parameters
        ----------
        partial_charge_method : string
            The partial charge calculation method to use for partial charge
            calculation.
        strict_n_conformers : bool, default=False
            Whether to raise an exception if an invalid number of conformers is
            provided for the given charge method. If this is False and an
            invalid number of conformers is found, a warning will be raised.
        use_conformers : Arrays with shape (n_atoms, 3) and dimensions of distance
            Coordinates to use for partial charge calculation. If ``None``, an
            appropriate number of conformers will be generated.
        toolkit_registry
            :class:`ToolkitRegistry` or :class:`ToolkitWrapper` to use for the
            calculation.
        normalize_partial_charges : bool, default=True
            Whether to offset partial charges so that they sum to the total
            formal charge of the molecule. This is used to prevent accumulation
            of rounding errors when the partial charge assignment method returns
            values at limited precision.

        Examples
        --------

        To use pre-generated conformations, use the ``use_conformers`` argument:

        >>> molecule = Molecule.from_smiles('CCCCCC')
        >>> molecule.generate_conformers(n_conformers=1)
        >>> molecule.assign_partial_charges(
        ...     'am1-mulliken',
        ...     use_conformers=molecule.conformers
        ... )
