### PR TITLE
Provide an explicit error message for GAFFTemplateGenerator when AmberTools is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The `openmmforcefields` package includes a [residue template generator](http://d
 ### Cheminformatics toolkits
 
 The [`openff-toolkit`](http://openforcefield.org) is used to provide an interface with cheminformatics toolkits to interact with [`antechamber`](http://ambermd.org/antechamber/) from the [AmberTools](http://ambermd.org/AmberTools.php) package to generate parameters for small molecules.
+Note that AmberTools is not installed automatically as a dependency when installing `openmmforcefields` through `conda` as described above.  To use this template generator, first [download and install](http://ambermd.org/GetAmber.php#ambertools) AmberTools manually, either through `conda` if supported on your platform, or by compiling from source.
 By default, the [`openff-toolkit`](http://github.com/openforcefield/openff-toolkit) will make use of the free and open source [RDKit cheminformatics toolkit](https://www.rdkit.org/) that is installed automatically, but will optionally use the [OpenEye toolkit](https://docs.eyesopen.com/toolkits/python/index.html) if it is installed and licensed.
 The OpenEye toolkit is available [for free for academics for non-IP-generating academic research](https://www.eyesopen.com/academic-licensing).
 

--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -14,6 +14,7 @@ Residue template generator for the AMBER GAFF1/2 small molecule force fields.
 import contextlib
 import logging
 import os
+import shutil
 import warnings
 
 _logger = logging.getLogger("openmmforcefields.generators.template_generators")
@@ -434,6 +435,8 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
         "gaff-2.11",
     ]
 
+    _ANTECHAMBER_AVAILABLE = None
+
     def __init__(self, molecules=None, forcefield=None, cache=None, **kwargs):
         """
         Create a GAFFTemplateGenerator with some OpenFF toolkit molecules
@@ -504,6 +507,9 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
         Newly parameterized molecules will be written to the cache, saving time next time!
         """
 
+        if not self._check_antechamber_available():
+            raise ValueError("GAFFTemplateGenerator requires AmberTools, available at <https://ambermd.org/AmberTools.php>")
+
         # Initialize molecules and cache
         super().__init__(molecules=molecules, cache=cache)
 
@@ -539,6 +545,12 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
         self._gaff_parameters_loaded = dict()
         # Track which atom types we have told OpenMM about
         self._gaff_atom_types_observed = set()
+
+    @classmethod
+    def _check_antechamber_available(cls):
+        if cls._ANTECHAMBER_AVAILABLE is None:
+            cls._ANTECHAMBER_AVAILABLE = shutil.which("antechamber") is not None
+        return cls._ANTECHAMBER_AVAILABLE
 
     @property
     def gaff_version(self):


### PR DESCRIPTION
Related to removal of AmberTools as an explicit dependency (conda-forge/openmmforcefields-feedstock#19): since now it might not be installed by the user, this raises an exception right away to explain this when it can't be located rather than having OpenFF produce a more cryptic error.