### PR TITLE
Update macOS and OpenMM versions in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,11 +27,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, macos-latest]
+        os: [ubuntu-latest, macos-13, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
         amber-conversion: [false]
         charmm-conversion: [false]
-        openmm-version: ["8.1.1", "8.1.2"]
+        openmm-version: ["8.1.2", "8.2.0"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
`macos-12` is deprecated and as of now is completely unsupported causing those CI runs to fail: see <https://github.com/actions/runner-images/issues/10721>.

This also updates the OpenMM versions to the latest two releases.  I am assuming that this is the convention used; please correct if not.