### PR TITLE
Test new ambertools 24  build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
         amber-conversion: [false]
         charmm-conversion: [false]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, macos-13]
         python-version: ["3.10", "3.11", "3.12"]
         amber-conversion: [false]
         charmm-conversion: [false]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, macos-latest]
+        os: [ubuntu-latest, macos-13, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
         amber-conversion: [false]
         charmm-conversion: [false]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
         amber-conversion: [false]
         charmm-conversion: [false]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
         amber-conversion: [false]
         charmm-conversion: [false]
-        openmm-version: ["8.1.1", "8.1.2"]
+        openmm-version: ["8.1.2", "8.2.0"]
 
     steps:
     - uses: actions/checkout@v4

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -11,7 +11,7 @@ dependencies:
   - openmm
   - openff-toolkit >=0.11
   - pyyaml
-  - ambertools=23.6=*_105
+  - ambertools >=24
   - lxml
   - networkx
   - tinydb

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -11,7 +11,7 @@ dependencies:
   - openmm
   - openff-toolkit >=0.11
   - pyyaml
-  - ambertools >=22,<24
+  - ambertools=23.6=*_105
   - lxml
   - networkx
   - tinydb


### PR DESCRIPTION
First I want to make sure CI is green, then I will see if tests pass installing `ambertools` from outside `conda-forge`