### PR TITLE
Downpin away from openff-interchange 0.4.2 in CI

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -10,6 +10,7 @@ dependencies:
   - pytest-randomly
   - openmm
   - openff-toolkit >=0.11
+  - openff-interchange =0.4.1
   - pyyaml
   - ambertools >=22,<24
   - lxml


### PR DESCRIPTION
A quick fix to get CI green for the problem reported in #365 