### PR TITLE
Remove duplicate atom type handling and re-enable GAFF tests

### DIFF
--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -535,11 +535,6 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
 
         self._database_table_name = os.path.basename(forcefield)
 
-        # Track which OpenMM ForceField objects have loaded the relevant GAFF parameters
-        self._gaff_parameters_loaded = dict()
-        # Track which atom types we have told OpenMM about
-        self._gaff_atom_types_observed = set()
-
     @property
     def gaff_version(self):
         """The current GAFF version in use"""
@@ -733,21 +728,6 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
         kwargs = {}
         if "write_unused" in signature(params.write).parameters:
             kwargs["write_unused"] = True
-
-        # We need to make sure we don't duplicate atom types we have already told
-        # OpenMM about. To do this we will keep track of atom types we have already
-        # seen and ensure we only record new atom types in the xml.
-
-        # iterate over a copy of the atom types
-        for atom_type in params.atom_types.copy().keys():
-            if atom_type not in self._gaff_atom_types_observed:
-                self._gaff_atom_types_observed.add(atom_type)
-                _logger.debug(f"added {atom_type} to set of seen types")
-            # if we have seen the atom type, delete it from the OG params,
-            # not the copy!
-            else:
-                del params.atom_types[atom_type]
-                _logger.debug(f"{atom_type} already recorded")
 
         params.write(ffxml, **kwargs)
         ffxml_contents = ffxml.getvalue()

--- a/openmmforcefields/tests/test_template_generators.py
+++ b/openmmforcefields/tests/test_template_generators.py
@@ -306,7 +306,7 @@ class TemplateGeneratorBaseCase(unittest.TestCase):
         return openmm_energy, openmm_forces
 
 
-@pytest.mark.skip(reason="Skip GAFF tests")
+@pytest.mark.rungaff
 class TestGAFFTemplateGenerator(TemplateGeneratorBaseCase):
     TEMPLATE_GENERATOR = GAFFTemplateGenerator
 


### PR DESCRIPTION
To fix #369.  Also remove `_gaff_parameters_loaded` which was unused and does not appear anywhere else.  Enable GAFF tests again on `--rungaff`.