### PR TITLE
Fix espaloma model download race conditions

### DIFF
--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -1867,21 +1867,24 @@ class EspalomaTemplateGenerator(SmallMoleculeTemplateGenerator, OpenMMSystemMixi
                 return cached_filename
             else:
                 # Create the cache directory
-                if not os.path.exists(self.ESPALOMA_MODEL_CACHE_PATH):
-                    os.makedirs(self.ESPALOMA_MODEL_CACHE_PATH)
+                os.makedirs(self.ESPALOMA_MODEL_CACHE_PATH, exist_ok=True)
 
                 # Attempt to retrieve from URL
                 _logger.info(f"Attempting to retrieve espaloma model from {url}")
+                import tempfile
                 import urllib
                 import urllib.error
                 import urllib.request
 
-                try:
-                    urllib.request.urlretrieve(url, filename=cached_filename)
-                except urllib.error.URLError:
-                    raise ValueError(f"No espaloma model found at expected URL: {url}")
-                except urllib.error.HTTPError as e:
-                    raise ValueError(f"An error occurred while retrieving espaloma model from {url} : {e}")
+                with tempfile.TemporaryDirectory(dir=self.ESPALOMA_MODEL_CACHE_PATH) as temp_dir:
+                    temp_filename = os.path.join(temp_dir, filename)
+                    try:
+                        urllib.request.urlretrieve(url, filename=temp_filename)
+                    except urllib.error.URLError:
+                        raise ValueError(f"No espaloma model found at expected URL: {url}")
+                    except urllib.error.HTTPError as e:
+                        raise ValueError(f"An error occurred while retrieving espaloma model from {url} : {e}")
+                    os.replace(temp_filename, cached_filename)
                 return cached_filename
 
     @property


### PR DESCRIPTION
This is an attempt to fix race conditions when multiple processes are trying to download espaloma models simultaneously (I believe this was the likely cause of test failures I saw in #397).  Specifically, if a process creates `ESPALOMA_MODEL_CACHE_PATH` in between another one checking that it doesn't exist and trying to create it, the second process would fail.  Also, if a process sees that the PyTorch model file exists, it would try to read it even if another process is still in the middle of downloading it, so it will run into an early EOF.

Here `makedirs(exist_ok=True)` should fix the first problem, and downloading to a temporary location before doing what should be an atomic rename should fix the second.  I suspect CI failures from these problems would be intermittent, but I can reliably reproduce them locally, and verify the fixes, by deleting `~/.espaloma` and running just the espaloma tests in parallel.