### PR TITLE
Using stdlib `importlib.resources` instead of `importlib_resources`

### DIFF
--- a/openmmforcefields/generators/template_generators.py
+++ b/openmmforcefields/generators/template_generators.py
@@ -560,10 +560,10 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
     @property
     def gaff_dat_filename(self):
         """File path to the GAFF .dat AMBER force field file"""
-        import importlib_resources
+        import importlib.resources
 
         filename = str(
-            importlib_resources.files("openmmforcefields")
+            importlib.resources.files("openmmforcefields")
             / "ffxml"
             / "amber"
             / "gaff"
@@ -575,10 +575,10 @@ class GAFFTemplateGenerator(SmallMoleculeTemplateGenerator):
     @property
     def gaff_xml_filename(self):
         """File path to the GAFF .ffxml OpenMM force field file"""
-        import importlib_resources
+        import importlib.resources
 
         filename = str(
-            importlib_resources.files("openmmforcefields")
+            importlib.resources.files("openmmforcefields")
             / "ffxml"
             / "amber"
             / "gaff"

--- a/openmmforcefields/tests/test_amber_import.py
+++ b/openmmforcefields/tests/test_amber_import.py
@@ -87,7 +87,7 @@ def test_amber_parameterize_ff94():
     Test parameterizing explicit villin with ff94
 
     """
-    import importlib_resources
+    import importlib.resources
 
-    pdb_filename = str(importlib_resources.files("openmm.app") / "data" / "test.pdb")
+    pdb_filename = str(importlib.resources.files("openmm.app") / "data" / "test.pdb")
     check_ffxml_parameterize(pdb_filename, "amber/ff94.xml")

--- a/openmmforcefields/utils.py
+++ b/openmmforcefields/utils.py
@@ -2,7 +2,7 @@ import contextlib
 import functools
 import logging
 import time
-import importlib_resources
+import importlib.resources
 
 _logger = logging.getLogger("openmmforcefields.utils")
 
@@ -22,7 +22,7 @@ def get_ffxml_path():
         The absolute path where OpenMM ffxml forcefield files are stored in this package
     """
 
-    filename = importlib_resources.files("openmmforcefields") / "ffxml"
+    filename = importlib.resources.files("openmmforcefields") / "ffxml"
     return str(filename.absolute())
 
 
@@ -44,7 +44,7 @@ def get_data_filename(relative_path):
     Absolute path to file
     """
 
-    fn = importlib_resources.files("openmmforcefields") / "data" / relative_path
+    fn = importlib.resources.files("openmmforcefields") / "data" / relative_path
 
     import os
 


### PR DESCRIPTION
Just a minor nice to have. We could do the same without relying on the third party `importlib_resources`, and instead using the stdlib `importlib.resources` package.