### PR TITLE
Bump OpenMM versions in CI to include 8.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.11", "3.12", "3.13"]
         amber-conversion: [false]
-        openmm-version: ["8.2.0", "8.3.1"]
+        openmm-version: ["8.3.1", "8.4.0"]
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/test_charmm.yaml
+++ b/.github/workflows/test_charmm.yaml
@@ -24,8 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12"]
-        openmm-version: ["8.3.1"]
+        python-version: ["3.13"]
+        openmm-version: ["8.4.0"]
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
We should test with 8.4.0 now that it's out.

I think we can't bump the Python versions yet because at least `openff-toolkit` isn't available for 3.14.