### PR TITLE
[DNM] Test Ambertools 25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
         python-version: ["3.12"]
         amber-conversion: [false]
         openmm-version: ["8.5.1"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
           espaloma==0.4.0
 
     - name: Setup Conda Environment
-      if: matrix.python-version == '3.13'
+      if: matrix.python-version == '3.12'
       uses: mamba-org/setup-micromamba@v3
       with:
         environment-file: devtools/conda-envs/test_env.yaml
@@ -68,7 +68,7 @@ jobs:
         python -c "from openmmforcefields import __version__, __file__; print(__version__, __file__)"
 
     - name: Test Installed Package (With Espaloma)
-      if: matrix.python-version != '3.13'
+      if: matrix.python-version != '3.12'
       env:
         COV_ARGS: --cov=openmmforcefields --cov-config=setup.cfg --cov-append --cov-report=xml
         LOGLEVEL: "INFO"
@@ -83,7 +83,7 @@ jobs:
           openmmforcefields/tests/
 
     - name: Test Installed Package
-      if: matrix.python-version == '3.13'
+      if: matrix.python-version == '3.12'
       env:
         COV_ARGS: --cov=openmmforcefields --cov-config=setup.cfg --cov-append --cov-report=xml
         LOGLEVEL: "INFO"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.12"]
         amber-conversion: [false]
         openmm-version: ["8.5.1"]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Setup Conda Environment with espaloma
-      if: matrix.python-version != '3.13'
+      if: matrix.python-version != '3.12'
       uses: mamba-org/setup-micromamba@v3
       with:
         environment-file: devtools/conda-envs/test_env.yaml

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,8 +1,9 @@
 name: openmmforcefields-test
 channels:
+  - mmh/label/amber25
   - conda-forge
 dependencies:
-  - ambertools >=24
+  - ambertools >=25
   - lxml
   - numpy <2.3
   - openff-toolkit >=0.11


### PR DESCRIPTION
I wanted to test ambertools 25 before I released it in some downstream envs, I only have uploaded the python 3.12 builds for linuxm, osx, and arm64 since I have limited space in my anaconda channel.  